### PR TITLE
Fix sleep timer to use target time instead of duration

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/playback/SleepTimer.kt
+++ b/app/src/main/kotlin/com/music/vivi/playback/SleepTimer.kt
@@ -24,16 +24,16 @@ class SleepTimer(
     val isActive: Boolean
         get() = triggerTime != -1L || pauseWhenSongEnd
 
-    fun start(minute: Int) {
+    fun start(durationMillis: Long) {
         sleepTimerJob?.cancel()
         sleepTimerJob = null
-        if (minute == -1) {
+        if (durationMillis == -1L) {
             pauseWhenSongEnd = true
         } else {
-            triggerTime = System.currentTimeMillis() + minute.minutes.inWholeMilliseconds
+            triggerTime = System.currentTimeMillis() + durationMillis
             sleepTimerJob =
                 scope.launch {
-                    delay(minute.minutes)
+                    delay(durationMillis)
                     player.pause()
                     triggerTime = -1L
                 }

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
@@ -373,7 +373,7 @@ fun BottomSheetPlayer(
                 TextButton(
                     onClick = {
                         showSleepTimerDialog = false
-                        playerConnection.service.sleepTimer.start(sleepTimerValue.roundToInt())
+                        playerConnection.service.sleepTimer.start(sleepTimerValue.roundToInt() * 60 * 1000L)
                     },
                 ) {
                     Text(stringResource(android.R.string.ok))
@@ -407,7 +407,7 @@ fun BottomSheetPlayer(
                     OutlinedIconButton(
                         onClick = {
                             showSleepTimerDialog = false
-                            playerConnection.service.sleepTimer.start(-1)
+                            playerConnection.service.sleepTimer.start(-1L)
                         },
                     ) {
                         Text(stringResource(R.string.end_of_song))

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Queue.kt
@@ -123,6 +123,7 @@ import kotlinx.coroutines.launch
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -530,9 +531,21 @@ fun Queue(
                     },
                     onDismiss = { showSleepTimerDialog = false },
                     onConfirm = {
-                        val totalMinutes = sleepTimerState.hour * 60 + sleepTimerState.minute
-                        if (totalMinutes > 0) {
-                            playerConnection.service.sleepTimer.start(totalMinutes)
+                        val calendar = Calendar.getInstance()
+                        val currentHour = calendar.get(Calendar.HOUR_OF_DAY)
+                        val currentMinute = calendar.get(Calendar.MINUTE)
+                        val currentSecond = calendar.get(Calendar.SECOND)
+
+                        val currentTimeInMillis = (currentHour * 3600 + currentMinute * 60 + currentSecond) * 1000L
+                        val targetTimeInMillis = (sleepTimerState.hour * 3600 + sleepTimerState.minute * 60) * 1000L
+
+                        var diff = targetTimeInMillis - currentTimeInMillis
+                        if (diff < 0) {
+                            diff += 24 * 3600 * 1000L
+                        }
+
+                        if (diff > 0) {
+                            playerConnection.service.sleepTimer.start(diff)
                         }
                         showSleepTimerDialog = false
                     },
@@ -553,7 +566,7 @@ fun Queue(
                             OutlinedButton(
                                 onClick = {
                                     showSleepTimerDialog = false
-                                    playerConnection.service.sleepTimer.start(-1)
+                                    playerConnection.service.sleepTimer.start(-1L)
                                 }
                             ) {
                                 Text(stringResource(R.string.end_of_song))


### PR DESCRIPTION
## Description
This PR fixes an issue where the sleep timer in the queue sheet was incorrectly interpreting the selected time as a duration (e.g., setting 12:30 AM would set a timer for 30 minutes) instead of a target time of day.

## Changes
- **Logic Fix**: The sleep timer now correctly calculates the duration between the current time and the selected target time. If the target time is earlier than the current time, it is assumed to be for the next day.
- **Precision Upgrade**: Updated `SleepTimer.kt` to accept duration in milliseconds instead of minutes.
- **UI Updates**:
    - `Queue.kt`: Now calculates the exact time difference including seconds for better precision.
    - `Player.kt`: Updated the slider-based timer to convert minutes to milliseconds to match the new API.

## Related Issue
Fixes #151