### PR TITLE
fix: bugfix for playback after reboot crash

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/music/vivi/playback/MusicService.kt
@@ -303,6 +303,7 @@ class MusicService :
 
     override fun onCreate() {
         super.onCreate()
+        isRunning = true
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             setListener(object : Listener {
                 override fun onForegroundServiceStartNotAllowedException() {
@@ -1916,6 +1917,7 @@ class MusicService :
     }
 
     override fun onDestroy() {
+        isRunning = false
         if (dataStore.get(PersistentQueueKey, true)) {
             saveQueueToDisk()
         }
@@ -2027,5 +2029,6 @@ class MusicService :
         private const val MIN_GAIN_MB = -1000 // Minimum gain in millibels (-8 dB)
 
         private const val TAG = "MusicService"
+        var isRunning = false
     }
 }

--- a/app/src/main/kotlin/com/music/vivi/update/widget/MusicWavesWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/music/vivi/update/widget/MusicWavesWidgetReceiver.kt
@@ -15,17 +15,19 @@ class MusicWavesWidgetReceiver : AppWidgetProvider() {
         appWidgetIds: IntArray
     ) {
         // Trigger update through MusicService if running
-        val intent = Intent(context, MusicService::class.java).apply {
-            action = MusicPlayerWidgetReceiver.ACTION_UPDATE_WIDGET
-        }
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
+        if (MusicService.isRunning) {
+            val intent = Intent(context, MusicService::class.java).apply {
+                action = MusicPlayerWidgetReceiver.ACTION_UPDATE_WIDGET
             }
-        } catch (e: Exception) {
-            // Service might be restricted in background
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                // Service might be restricted in background
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/music/vivi/update/widget/viviwidget.kt
+++ b/app/src/main/kotlin/com/music/vivi/update/widget/viviwidget.kt
@@ -16,17 +16,19 @@ class MusicPlayerWidgetReceiver : AppWidgetProvider() {
         appWidgetIds: IntArray
     ) {
         // Trigger update through MusicService if running
-        val intent = Intent(context, MusicService::class.java).apply {
-            action = ACTION_UPDATE_WIDGET
-        }
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
+        if (MusicService.isRunning) {
+            val intent = Intent(context, MusicService::class.java).apply {
+                action = ACTION_UPDATE_WIDGET
             }
-        } catch (e: Exception) {
-            // Service might be restricted in background
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    context.startForegroundService(intent)
+                } else {
+                    context.startService(intent)
+                }
+            } catch (e: Exception) {
+                // Service might be restricted in background
+            }
         }
     }
 
@@ -35,6 +37,23 @@ class MusicPlayerWidgetReceiver : AppWidgetProvider() {
 
         when (intent.action) {
             ACTION_PLAY_PAUSE, ACTION_LIKE, ACTION_PLAY_SONG, ACTION_PLAY_QUEUE_ITEM -> {
+                // For user interactions, we might be able to start the service, 
+                // but if we are in BOOT_COMPLETED flow (which shouldn't hit this path typically, but effectively similar restriction for background start)
+                // However, these are explicit user actions on the widget buttons. 
+                // Android 12+ allows starting FGS from background if triggered by widget interaction? 
+                // Wait, "FGS type mediaPlayback not allowed to start from BOOT_COMPLETED".
+                // The crash happened on BOOT_COMPLETED.
+                // The stack trace says: "FGS type mediaPlayback not allowed to start from BOOT_COMPLETED!"
+                // This exception usually happens when a BroadcastReceiver trying to start an FGS from background (e.g. after boot).
+                
+                // If it's a direct user interaction, we usually can start it. 
+                // But let's be safe. If the user clicks play, we WANT to start the service.
+                // But the crash report says "BOOT_COMPLETED", implying it wasn't a user click.
+                
+                // The widget update logic in `onUpdate` is the main culprit for boot crashes.
+                // But let's verify if we need to guard here too.
+                // Usually widget buttons send PendingIntents.
+                
                 val serviceIntent = Intent(context, MusicService::class.java).apply {
                     action = intent.action
                     putExtras(intent)


### PR DESCRIPTION
The crash happened on BOOT_COMPLETED.
 The stack trace says: "FGS type mediaPlayback not allowed to start from BOOT_COMPLETED!"
 This exception usually happens when a BroadcastReceiver trying to start an FGS from background (e.g. after boot).

 The widget update logic in `onUpdate` is the main culprit for boot crashes.

https://github.com/vivizzz007/vivi-music/issues/272 Contributed with ♥️by @T-Boyke