### PR TITLE
fix(Artist): Parse localized artist stats

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/screens/artist/ArtistScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -43,7 +44,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -137,9 +137,7 @@ import com.valentinilk.shimmer.shimmer
 import com.music.vivi.artistvideo.ArtistVideo
 import com.music.vivi.constants.ShowArtistVideoKey
 import com.music.vivi.constants.ShowArtistBackgroundVideoKey
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ButtonDefaults
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -149,6 +147,7 @@ import com.music.vivi.canvas.AppleMusicArtistBackgroundProvider
 @Composable
 fun ArtistScreen(
     navController: NavController,
+    @Suppress("UNUSED_PARAMETER")
     scrollBehavior: TopAppBarScrollBehavior,
     viewModel: ArtistViewModel = hiltViewModel(),
 ) {
@@ -380,10 +379,8 @@ fun ArtistScreen(
                                                         .height(45.dp),
                                                     onClick = {
                                                         val watchEndpoint = artistVideoSong?.endpoint
-                                                            ?: artistPage?.artist?.radioEndpoint
-                                                        watchEndpoint?.let {
-                                                            playerConnection.playQueue(YouTubeQueue(it))
-                                                        }
+                                                            ?: radioEndpoint
+                                                        playerConnection.playQueue(YouTubeQueue(watchEndpoint))
                                                     }
                                                 )
                                             }
@@ -404,13 +401,15 @@ fun ArtistScreen(
                                     )
                                 }
 
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
+                                FlowRow(
                                     horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    modifier = Modifier.padding(bottom = 16.dp)
+                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(bottom = 16.dp)
                                 ) {
                                     if (showArtistSubscriberCount) {
-                                        artistPage?.subscriberCountText?.let { subscribers ->
+                                        artistPage?.subscriberCountText?.takeIf { it.isNotBlank() }?.let { subscribers ->
                                             Row(
                                                 verticalAlignment = Alignment.CenterVertically,
                                                 modifier = Modifier
@@ -426,17 +425,19 @@ fun ArtistScreen(
                                                 )
                                                 Spacer(modifier = Modifier.width(6.dp))
                                                 Text(
-                                                    text = "${subscribers.split(' ').firstOrNull() ?: ""} ${stringResource(R.string.subscribers)}",
+                                                    text = "$subscribers ${stringResource(R.string.subscribers)}",
                                                     style = MaterialTheme.typography.labelLarge,
                                                     color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                                    fontWeight = FontWeight.Medium
+                                                    fontWeight = FontWeight.Medium,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis
                                                 )
                                             }
                                         }
                                     }
 
                                     if (showMonthlyListeners) {
-                                        artistPage?.monthlyListenerCount?.let { monthlyListeners ->
+                                        artistPage?.monthlyListenerCount?.takeIf { it.isNotBlank() }?.let { monthlyListeners ->
                                             Row(
                                                 verticalAlignment = Alignment.CenterVertically,
                                                 modifier = Modifier
@@ -452,10 +453,12 @@ fun ArtistScreen(
                                                 )
                                                 Spacer(modifier = Modifier.width(6.dp))
                                                 Text(
-                                                    text = "${monthlyListeners.split(' ').firstOrNull() ?: ""} ${stringResource(R.string.monthly_listeners)}",
+                                                    text = "$monthlyListeners ${stringResource(R.string.monthly_listeners)}",
                                                     style = MaterialTheme.typography.labelLarge,
                                                     color = MaterialTheme.colorScheme.onTertiaryContainer,
-                                                    fontWeight = FontWeight.Medium
+                                                    fontWeight = FontWeight.Medium,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis
                                                 )
                                             }
                                         }
@@ -463,8 +466,8 @@ fun ArtistScreen(
                                 }
 
                                 if (!showLocal && showArtistDescription && artistPage != null) {
-                                    val description = artistPage?.description
-                                    val descriptionRuns = artistPage?.descriptionRuns
+                                    val description = artistPage.description
+                                    val descriptionRuns = artistPage.descriptionRuns
                                     
                                     if (!description.isNullOrEmpty() || !descriptionRuns.isNullOrEmpty()) {
                                         Column(
@@ -599,11 +602,7 @@ fun ArtistScreen(
                                                     .weight(1f)
                                                     .height(52.dp)
                                                     .semantics { role = Role.Button },
-                                                shapes = if (artistPage?.artist?.radioEndpoint != null) {
-                                                    ButtonGroupDefaults.connectedTrailingButtonShapes()
-                                                } else {
-                                                    ButtonGroupDefaults.connectedTrailingButtonShapes()
-                                                }
+                                                shapes = ButtonGroupDefaults.connectedTrailingButtonShapes()
                                             ) {
                                                 Icon(
                                                     painter = painterResource(R.drawable.shuffle),
@@ -994,9 +993,9 @@ fun ArtistScreen(
                         
                         val moreEndpoint = songSection?.moreEndpoint
                         if (moreEndpoint != null) {
-                            coroutineScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                            coroutineScope.launch(Dispatchers.IO) {
                                 val result = YouTube.artistItems(moreEndpoint).getOrNull()
-                                withContext(kotlinx.coroutines.Dispatchers.Main) {
+                                withContext(Dispatchers.Main) {
                                     if (result != null && result.items.isNotEmpty()) {
                                         val songs = result.items.filterIsInstance<SongItem>().map { it.toMediaItem() }
                                         playerConnection.playQueue(

--- a/innertube/src/main/kotlin/com/music/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/music/innertube/YouTube.kt
@@ -23,6 +23,7 @@ import com.music.innertube.models.YouTubeClient
 import com.music.innertube.models.YouTubeClient.Companion.WEB
 import com.music.innertube.models.YouTubeClient.Companion.WEB_REMIX
 import com.music.innertube.models.YouTubeLocale
+import com.music.innertube.models.extractCountText
 import com.music.innertube.models.getContinuation
 import com.music.innertube.models.getItems
 import com.music.innertube.models.oddElements
@@ -433,13 +434,13 @@ object YouTube {
                 ?.tabRenderer?.content?.sectionListRenderer?.contents
                 ?.mapNotNull(ArtistPage::fromSectionListRendererContent)!!,
             description = descriptionRuns?.joinToString(separator = "") { it.text },
-                subscriberCountText = response.header?.musicImmersiveHeaderRenderer?.subscriptionButton2
-                    ?.subscribeButtonRenderer?.subscriberCountWithSubscribeText?.runs?.firstOrNull()?.text
-                    ?: response.header?.musicImmersiveHeaderRenderer?.subscriptionButton?.subscribeButtonRenderer
-                        ?.longSubscriberCountText?.runs?.firstOrNull()?.text
-                    ?: response.header?.musicImmersiveHeaderRenderer?.subscriptionButton?.subscribeButtonRenderer
-                        ?.shortSubscriberCountText?.runs?.firstOrNull()?.text,
-            monthlyListenerCount = response.header?.musicImmersiveHeaderRenderer?.monthlyListenerCount?.runs?.firstOrNull()?.text,
+            subscriberCountText = response.header?.musicImmersiveHeaderRenderer?.subscriptionButton2
+                ?.subscribeButtonRenderer?.subscriberCountWithSubscribeText.extractCountText()
+                ?: response.header?.musicImmersiveHeaderRenderer?.subscriptionButton?.subscribeButtonRenderer
+                    ?.longSubscriberCountText.extractCountText()
+                ?: response.header?.musicImmersiveHeaderRenderer?.subscriptionButton?.subscribeButtonRenderer
+                    ?.shortSubscriberCountText.extractCountText(),
+            monthlyListenerCount = response.header?.musicImmersiveHeaderRenderer?.monthlyListenerCount.extractCountText(),
             descriptionRuns = descriptionRuns
         )
     }

--- a/innertube/src/main/kotlin/com/music/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/music/innertube/models/Runs.kt
@@ -13,6 +13,31 @@ data class Run(
     val navigationEndpoint: NavigationEndpoint?,
 )
 
+private const val compactCountSuffixPattern =
+    "KkMmBbTt\\u4e07\\u842c\\u5104\\u4ebf\\u5146\\u5343\\ucc9c\\ub9cc\\uc5b5"
+private val countTextRegex =
+    Regex("""\p{Nd}[\p{Nd}\s,.\uFF0C\uFF0E]*[$compactCountSuffixPattern]*""")
+private val separatedSuffixRegex = Regex("""\s+(?=[$compactCountSuffixPattern]$)""")
+
+internal fun Runs?.extractCountText(): String? {
+    val texts = this?.runs
+        ?.map { it.text.trim() }
+        ?.filter { it.isNotEmpty() }
+        .orEmpty()
+
+    return texts
+        .joinToString(separator = "")
+        .extractCountValue()
+        ?: texts.firstNotNullOfOrNull { it.extractCountValue() }
+}
+
+private fun String.extractCountValue(): String? =
+    countTextRegex.find(this)
+        ?.value
+        ?.trim()
+        ?.replace(separatedSuffixRegex, "")
+        ?.takeIf { value -> value.any { it.isDigit() } }
+
 fun List<Run>.splitBySeparator(): List<List<Run>> {
     val res = mutableListOf<List<Run>>()
     var tmp = mutableListOf<Run>()

--- a/innertube/src/test/kotlin/com/music/innertube/models/RunsTest.kt
+++ b/innertube/src/test/kotlin/com/music/innertube/models/RunsTest.kt
@@ -1,0 +1,47 @@
+package com.music.innertube.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class RunsTest {
+    @Test
+    fun extractCountTextReadsEnglishSplitRuns() {
+        assertEquals("653K", runs("653K", " subscribers").extractCountText())
+    }
+
+    @Test
+    fun extractCountTextReadsJapaneseLabelBeforeCount() {
+        assertEquals("653K", runs(CHANNEL_SUBSCRIBER_COUNT, "653K").extractCountText())
+    }
+
+    @Test
+    fun extractCountTextReadsJapaneseMonthlyLabelBeforeCount() {
+        assertEquals("12.2M", runs("$MONTHLY_LISTENER_COUNT: ", "12.2M").extractCountText())
+    }
+
+    @Test
+    fun extractCountTextReadsSingleRunWithLabel() {
+        assertEquals("653K", runs("653K subscribers").extractCountText())
+    }
+
+    @Test
+    fun extractCountTextKeepsJapaneseCompactUnit() {
+        assertEquals("123\u4e07", runs("$MONTHLY_LISTENER_COUNT 123\u4e07").extractCountText())
+    }
+
+    @Test
+    fun extractCountTextReturnsNullForLabelOnly() {
+        assertNull(runs(CHANNEL_SUBSCRIBER_COUNT).extractCountText())
+    }
+
+    private fun runs(vararg texts: String) =
+        Runs(texts.map { Run(text = it, navigationEndpoint = null) })
+
+    private companion object {
+        private const val CHANNEL_SUBSCRIBER_COUNT =
+            "\u30c1\u30e3\u30f3\u30cd\u30eb\u767b\u9332\u8005\u6570"
+        private const val MONTHLY_LISTENER_COUNT =
+            "\u6708\u9593\u8996\u8074\u8005\u6570"
+    }
+}


### PR DESCRIPTION
## 🚀 What does this PR do?
- [x] 🐛 Fixes a bug (Issue #___)
- [ ] ✨ Adds a new feature
- [x] 🎨 UI/Design update
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code refactoring

This fixes localized artist stat parsing when the YouTube Music content language changes the order of text runs. In Japanese, labels such as subscriber/monthly listener text can appear before the numeric value, which previously caused the artist stats chips to render label-only text and collapse vertically

Changes:
- Extract numeric count text from all InnerTube `Runs` instead of assuming the first run contains the count
- Hide artist stat chips when no numeric count is available
- Allow the stat chips to wrap and keep their text to one line with ellipsis to avoid vertical layout collapse
- Add unit tests for English and Japanese run layouts

## 📸 Screenshots / Recordings
Before: Japanese content language could show label-only subscriber text and a vertically collapsed monthly listener chip
<img width="1080" height="2340" alt="Screenshot_20260530_192635_VIVI" src="https://github.com/user-attachments/assets/afd557f6-d731-402c-b3b4-279de39e6eed" />

After: Japanese content language displays localized numeric counts correctly, such as "3970万 チャンネル登録者数" and "2.38億 Monthly", without the monthly listener chip collapsing
<img width="1080" height="2340" alt="Screenshot_20260530_192732_VIVI Debug" src="https://github.com/user-attachments/assets/2f4b2f63-5feb-451a-8909-7b09668b2ec3" />

## 🛠️ Checklist
- [x] My code follows the project's style guidelines.
- [x] I have tested my changes on an Android device/emulator (Samsung Galaxy S26, OPPO Find X9 Pro).
- [x] I have verified that no new warnings/errors are introduced.
- [x] I have updated the documentation (if necessary).

## 📝 Additional Notes
- No documentation changes were necessary
- No string resources were changed
- Verified with:
  - `./gradlew :innertube:testDebugUnitTest`
  - `./gradlew :app:assembleuniversalFossDebug`