### PR TITLE
feat(player): add ambient fade player background style with theme adaptation

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
@@ -452,6 +452,7 @@ enum class PlayerBackgroundStyle {
     GLOW_ANIMATED,
     APPLE_MUSIC,
     LIVE_MESH,
+    AMBIENT_FADE,
 }
 
 val TopSize = stringPreferencesKey("topSize")
@@ -460,6 +461,7 @@ val HistoryDuration = floatPreferencesKey("historyDuration")
 val PlayerButtonsStyleKey = stringPreferencesKey("player_buttons_style")
 val PlayerBackgroundStyleKey = stringPreferencesKey("playerBackgroundStyle")
 val MiniPlayerBackgroundStyleKey = stringPreferencesKey("miniPlayerBackgroundStyle")
+val FollowColorThemeKey = booleanPreferencesKey("followColorTheme")
 val ShowLyricsKey = booleanPreferencesKey("showLyrics")
 val SwipeLyricsKey = booleanPreferencesKey("swipeLyrics")
 val EnableLyricsThumbnailPlayPauseKey = booleanPreferencesKey("enableLyricsThumbnailPlayPause")

--- a/app/src/main/kotlin/com/music/vivi/ui/component/Lyrics.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/component/Lyrics.kt
@@ -546,7 +546,7 @@ fun Lyrics(
     // Use Material 3 expressive accents and keep glow/text colors unified
     val expressiveAccent = when (playerBackground) {
         PlayerBackgroundStyle.DEFAULT -> MaterialTheme.colorScheme.primary
-        PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH -> {
+        PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH, PlayerBackgroundStyle.AMBIENT_FADE -> {
             // For animated or processed backgrounds, always use light colors regardless of theme
             Color.White
         }

--- a/app/src/main/kotlin/com/music/vivi/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/MiniPlayer.kt
@@ -118,6 +118,7 @@ import com.music.vivi.constants.SwipeSensitivityKey
 import com.music.vivi.constants.SwipeThumbnailKey
 import com.music.vivi.constants.ThumbnailCornerRadius
 import com.music.vivi.constants.UseNewMiniPlayerDesignKey
+import com.music.vivi.constants.FollowColorThemeKey
 import com.music.vivi.db.entities.ArtistEntity
 import com.music.vivi.listentogether.ListenTogetherManager
 import com.music.vivi.models.MediaMetadata
@@ -209,6 +210,7 @@ private fun NewMiniPlayer(
     }
     
     val miniPlayerBackground by rememberEnumPreference(MiniPlayerBackgroundStyleKey, defaultValue = PlayerBackgroundStyle.DEFAULT)
+    val followColorTheme by rememberPreference(FollowColorThemeKey, defaultValue = false)
     
     // Player states - only collect what's needed at this level
     val playbackState by playerConnection.playbackState.collectAsState()
@@ -269,13 +271,16 @@ private fun NewMiniPlayer(
         onGradientColorsChange = onGradientColorsChange
     )
     
-    // Memoize colors
-    val backgroundColor = if (pureBlack && useDarkTheme) Color.Black else MaterialTheme.colorScheme.surfaceContainer
-    val isDynamicBackground = miniPlayerBackground != PlayerBackgroundStyle.DEFAULT
+    val backgroundColor = when (miniPlayerBackground) {
+        PlayerBackgroundStyle.AMBIENT_FADE -> if (followColorTheme && !useDarkTheme) Color.White else Color.Black
+        else -> if (pureBlack && useDarkTheme) Color.Black else MaterialTheme.colorScheme.surfaceContainer
+    }
+    val isThemeAdaptingBackground = miniPlayerBackground == PlayerBackgroundStyle.DEFAULT || 
+        (miniPlayerBackground == PlayerBackgroundStyle.AMBIENT_FADE && followColorTheme)
     
-    val primaryColor = if (isDynamicBackground) Color.White else MaterialTheme.colorScheme.primary
-    val outlineColor = if (isDynamicBackground) Color.White.copy(alpha = 0.5f) else MaterialTheme.colorScheme.outline
-    val onSurfaceColor = if (isDynamicBackground) Color.White else MaterialTheme.colorScheme.onSurface
+    val primaryColor = if (isThemeAdaptingBackground && !useDarkTheme) MaterialTheme.colorScheme.primary else Color.White
+    val outlineColor = if (isThemeAdaptingBackground && !useDarkTheme) MaterialTheme.colorScheme.outline else Color.White.copy(alpha = 0.5f)
+    val onSurfaceColor = if (isThemeAdaptingBackground && !useDarkTheme) MaterialTheme.colorScheme.onSurface else Color.White
     val errorColor = MaterialTheme.colorScheme.error
 
     Box(
@@ -1160,6 +1165,105 @@ private fun MiniPlayerBackgroundLayer(
                         .graphicsLayer { rotationZ = rotation.value }
                 )
                 Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.3f)))
+            }
+        }
+        PlayerBackgroundStyle.AMBIENT_FADE -> {
+            val pureBlack by rememberPreference(PureBlackMiniPlayerKey, defaultValue = false)
+            val isSystemInDarkTheme = isSystemInDarkTheme()
+            val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
+            val useDarkTheme = remember(darkTheme, isSystemInDarkTheme) {
+                if (darkTheme == DarkMode.AUTO) isSystemInDarkTheme else darkTheme == DarkMode.ON
+            }
+            val followColorTheme by rememberPreference(FollowColorThemeKey, defaultValue = false)
+            val baseBackgroundColor = if (followColorTheme && !useDarkTheme) Color.White else Color.Black
+
+            val infiniteTransition = rememberInfiniteTransition(label = "bottomMeshMini")
+            val rotation = infiniteTransition.animateFloat(
+                initialValue = 0f,
+                targetValue = 360f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(60000, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart
+                ),
+                label = "rotation"
+            )
+
+            Box(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                // Base background
+                Box(modifier = Modifier.fillMaxSize().background(baseBackgroundColor))
+                
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            scaleX = 1.5f
+                            scaleY = 1.5f
+                        }
+                ) {
+                    val matrix = remember(useDarkTheme, followColorTheme) { 
+                        val isLightMode = followColorTheme && !useDarkTheme
+                        val saturation = if (isLightMode) 3.0f else 1.6f
+                        val m = ColorMatrix().apply { setToSaturation(saturation) }
+                        val (min, max) = if (isLightMode) {
+                            Pair(0.15f, 0.85f)
+                        } else {
+                            Pair(0.0f, 0.7f)
+                        }
+                        val scale = max - min
+                        val offset = min
+                        for (row in 0 until 3) {
+                            val startIndex = row * 5
+                            for (col in 0 until 4) {
+                                m.values[startIndex + col] = m.values[startIndex + col] * scale
+                            }
+                            m.values[startIndex + 4] = m.values[startIndex + 4] * scale + offset
+                        }
+                        m
+                    }
+                    AsyncImage(
+                        model = ImageRequest.Builder(context)
+                            .data(mediaMetadata?.thumbnailUrl)
+                            .size(128, 128)
+                            .allowHardware(false)
+                            .build(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        colorFilter = ColorFilter.colorMatrix(matrix),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .blur(40.dp)
+                            .graphicsLayer { rotationZ = rotation.value }
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(
+                                baseBackgroundColor.copy(
+                                    alpha = if (followColorTheme && !useDarkTheme) 0.05f else 0.2f
+                                )
+                            )
+                    )
+                }
+                
+                // Smooth transition to theme background with an easing curve
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                colorStops = arrayOf(
+                                    0.0f to baseBackgroundColor,
+                                    0.3f to baseBackgroundColor,
+                                    0.55f to baseBackgroundColor.copy(alpha = 0.88f),
+                                    0.75f to baseBackgroundColor.copy(alpha = 0.5f),
+                                    0.9f to baseBackgroundColor.copy(alpha = 0.15f),
+                                    1.0f to Color.Transparent
+                                )
+                            )
+                        )
+                )
             }
         }
         else -> {}

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
@@ -105,6 +105,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
@@ -178,6 +179,7 @@ import com.music.vivi.constants.SquigglySliderKey
 import com.music.vivi.constants.SwipeLyricsKey
 import com.music.vivi.constants.ThumbnailCornerRadius
 import com.music.vivi.constants.UseNewPlayerDesignKey
+import com.music.vivi.constants.FollowColorThemeKey
 import com.music.vivi.constants.ShowAudioQualityBadgeKey
 import com.music.vivi.db.entities.LyricsEntity
 import com.music.vivi.extensions.SwipeGesture
@@ -274,6 +276,10 @@ fun BottomSheetPlayer(
         key = PlayerBackgroundStyleKey,
         defaultValue = PlayerBackgroundStyle.GRADIENT
     )
+    val followColorTheme by rememberPreference(
+        key = FollowColorThemeKey,
+        defaultValue = false
+    )
     val playerButtonsStyle by rememberEnumPreference(
         key = PlayerButtonsStyleKey,
         defaultValue = PlayerButtonsStyle.DEFAULT
@@ -284,13 +290,16 @@ fun BottomSheetPlayer(
     val useDarkTheme = remember(darkTheme, isSystemInDarkTheme) {
         if (darkTheme == DarkMode.AUTO) isSystemInDarkTheme else darkTheme == DarkMode.ON
     }
+    val sliderUseDarkTheme = remember(useDarkTheme, playerBackground, followColorTheme) {
+        if (playerBackground == PlayerBackgroundStyle.AMBIENT_FADE) (useDarkTheme || !followColorTheme) else useDarkTheme
+    }
 
     val enableCanvas by rememberPreference(CanvasThumbnailAnimationKey, true)
     val (canvasSource) = rememberEnumPreference(CanvasSourceKey, defaultValue = CanvasSource.AUTO)
 
     val shouldUseDarkButtonColors = remember(playerBackground, useDarkTheme) {
         when (playerBackground) {
-            PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH -> true
+            PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH, PlayerBackgroundStyle.AMBIENT_FADE -> true
             PlayerBackgroundStyle.DEFAULT -> useDarkTheme
         }
     }
@@ -301,7 +310,7 @@ fun BottomSheetPlayer(
     val isKeepScreenOn by rememberPreference(KeepScreenOn, false)
     val keepScreenOn = isPlaying && isKeepScreenOn
 
-    DisposableEffect(playerBackground, state.isExpanded, useDarkTheme, keepScreenOn) {
+    DisposableEffect(playerBackground, state.isExpanded, useDarkTheme, followColorTheme, keepScreenOn) {
         val window = (context as? android.app.Activity)?.window
         if (window != null && state.isExpanded) {
             val insetsController = WindowCompat.getInsetsController(window, window.decorView)
@@ -309,6 +318,9 @@ fun BottomSheetPlayer(
             when (playerBackground) {
                 PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH -> {
                     insetsController.isAppearanceLightStatusBars = false
+                }
+                PlayerBackgroundStyle.AMBIENT_FADE -> {
+                    insetsController.isAppearanceLightStatusBars = followColorTheme && !useDarkTheme
                 }
                 PlayerBackgroundStyle.DEFAULT -> {
                     insetsController.isAppearanceLightStatusBars = !useDarkTheme
@@ -535,6 +547,9 @@ fun BottomSheetPlayer(
             PlayerBackgroundStyle.GLOW_ANIMATED -> Color.White
             PlayerBackgroundStyle.APPLE_MUSIC -> Color.White
             PlayerBackgroundStyle.LIVE_MESH -> Color.White
+            PlayerBackgroundStyle.AMBIENT_FADE -> {
+                if (followColorTheme && !useDarkTheme) MaterialTheme.colorScheme.onBackground else Color.White
+            }
         },
         label = "TextBackgroundColor"
     )
@@ -547,6 +562,9 @@ fun BottomSheetPlayer(
             PlayerBackgroundStyle.GLOW_ANIMATED -> Color.Black
             PlayerBackgroundStyle.APPLE_MUSIC -> Color.Black
             PlayerBackgroundStyle.LIVE_MESH -> Color.Black
+            PlayerBackgroundStyle.AMBIENT_FADE -> {
+                if (followColorTheme && !useDarkTheme) MaterialTheme.colorScheme.surface else Color.Black
+            }
         },
         label = "icBackgroundColor"
     )
@@ -664,9 +682,10 @@ fun BottomSheetPlayer(
             }
         }
         else -> {
+            val isDark = if (playerBackground == PlayerBackgroundStyle.AMBIENT_FADE) (useDarkTheme || !followColorTheme) else useDarkTheme
             when (playerButtonsStyle) {
                 PlayerButtonsStyle.DEFAULT ->
-                    if (useDarkTheme) Pair(Color.White, Color.Black)
+                    if (isDark) Pair(Color.White, Color.Black)
                     else Pair(Color.Black, Color.White)
                 PlayerButtonsStyle.PRIMARY -> Pair(
                     MaterialTheme.colorScheme.primary,
@@ -824,6 +843,8 @@ fun BottomSheetPlayer(
             MaterialTheme.colorScheme.surfaceContainer
         PlayerBackgroundStyle.LIVE_MESH ->
             Color.Black
+        PlayerBackgroundStyle.AMBIENT_FADE ->
+            if (followColorTheme && !useDarkTheme) Color.White else Color.Black
         else ->
             if (useBlackBackground) Color.Black
             else MaterialTheme.colorScheme.surfaceContainer
@@ -1297,6 +1318,176 @@ fun BottomSheetPlayer(
                                                     listOf(
                                                         Color.Transparent,
                                                         Color.Black.copy(alpha = 0.25f)
+                                                    )
+                                                )
+                                            )
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    PlayerBackgroundStyle.AMBIENT_FADE -> {
+                        val infiniteTransition = rememberInfiniteTransition(label = "bottomMeshRotation")
+                        
+                        val anchorRotation by infiniteTransition.animateFloat(
+                            initialValue = 0f,
+                            targetValue = -360f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(80000, easing = LinearEasing),
+                                repeatMode = RepeatMode.Restart
+                            ),
+                            label = "anchorRotation"
+                        )
+                        
+                        val fastRotation by infiniteTransition.animateFloat(
+                            initialValue = 0f,
+                            targetValue = 360f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(40000, easing = LinearEasing),
+                                repeatMode = RepeatMode.Restart
+                            ),
+                            label = "fastRotation"
+                        )
+                        
+                        val slowRotation by infiniteTransition.animateFloat(
+                            initialValue = 0f,
+                            targetValue = 360f,
+                            animationSpec = infiniteRepeatable(
+                                animation = tween(60000, easing = LinearEasing),
+                                repeatMode = RepeatMode.Restart
+                            ),
+                            label = "slowRotation"
+                        )
+
+                        AnimatedContent(
+                            targetState = mediaMetadata?.thumbnailUrl,
+                            transitionSpec = {
+                                fadeIn(tween(1500)).togetherWith(fadeOut(tween(1500)))
+                            },
+                            label = "bottomMeshBackground"
+                        ) { thumbnailUrl ->
+                            if (thumbnailUrl != null) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .alpha(backgroundAlpha)
+                                ) {
+                                    // Theme-based background base
+                                    Box(modifier = Modifier.fillMaxSize().background(bottomSheetBackgroundColor))
+                                    
+                                    // Rotating blurred mesh layers
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .graphicsLayer {
+                                                scaleX = 1.7f
+                                                scaleY = 1.7f
+                                            }
+                                    ) {
+                                        val matrix = remember(useDarkTheme, followColorTheme) { 
+                                            val m = ColorMatrix()
+                                            val isLightMode = followColorTheme && !useDarkTheme
+                                            val saturation = if (isLightMode) 3.0f else 1.8f
+                                            m.setToSaturation(saturation)
+                                            val (min, max) = if (isLightMode) {
+                                                Pair(0.15f, 0.85f)
+                                            } else {
+                                                Pair(0.0f, 0.7f)
+                                            }
+                                            val scale = max - min
+                                            val offset = min
+                                            for (row in 0 until 3) {
+                                                val startIndex = row * 5
+                                                for (col in 0 until 4) {
+                                                    m.values[startIndex + col] = m.values[startIndex + col] * scale
+                                                }
+                                                m.values[startIndex + 4] = m.values[startIndex + 4] * scale + offset
+                                            }
+                                            m
+                                        }
+                                        val colorFilter = ColorFilter.colorMatrix(matrix)
+
+                                        // Layer 1: The Anchor (Full Image, Counter-Clockwise)
+                                        AsyncImage(
+                                            model = ImageRequest.Builder(context)
+                                                .data(thumbnailUrl)
+                                                .size(128, 128)
+                                                .allowHardware(false)
+                                                .build(),
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            colorFilter = colorFilter,
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .blur(100.dp)
+                                                .graphicsLayer { rotationZ = anchorRotation }
+                                        )
+
+                                        // Layer 2: Fast Rotating Crop (Top-Left)
+                                        AsyncImage(
+                                            model = ImageRequest.Builder(context)
+                                                .data(thumbnailUrl)
+                                                .size(128, 128)
+                                                .allowHardware(false)
+                                                .build(),
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            colorFilter = colorFilter,
+                                            alignment = Alignment.TopStart,
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .blur(120.dp)
+                                                .graphicsLayer { 
+                                                    rotationZ = fastRotation
+                                                    alpha = 0.6f
+                                                }
+                                        )
+
+                                        // Layer 3: Slow Rotating Crop (Bottom-Right)
+                                        AsyncImage(
+                                            model = ImageRequest.Builder(context)
+                                                .data(thumbnailUrl)
+                                                .size(128, 128)
+                                                .allowHardware(false)
+                                                .build(),
+                                            contentDescription = null,
+                                            contentScale = ContentScale.Crop,
+                                            colorFilter = colorFilter,
+                                            alignment = Alignment.BottomEnd,
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .blur(120.dp)
+                                                .graphicsLayer { 
+                                                    rotationZ = slowRotation
+                                                    alpha = 0.5f
+                                                }
+                                        )
+                                        
+                                        // Global tint to prevent neon look
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxSize()
+                                                .background(
+                                                    bottomSheetBackgroundColor.copy(
+                                                        alpha = if (followColorTheme && !useDarkTheme) 0.05f else 0.2f
+                                                    )
+                                                )
+                                        )
+                                    }
+                                    
+                                    // Smoothly transitions from theme background color to transparent with an easing curve
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .background(
+                                                Brush.verticalGradient(
+                                                    colorStops = arrayOf(
+                                                        0.0f to bottomSheetBackgroundColor,
+                                                        0.45f to bottomSheetBackgroundColor,
+                                                        0.65f to bottomSheetBackgroundColor.copy(alpha = 0.88f),
+                                                        0.8f to bottomSheetBackgroundColor.copy(alpha = 0.5f),
+                                                        0.92f to bottomSheetBackgroundColor.copy(alpha = 0.15f),
+                                                        1.0f to Color.Transparent
                                                     )
                                                 )
                                             )
@@ -1850,7 +2041,7 @@ fun BottomSheetPlayer(
                         colors = PlayerSliderColors.getSliderColors(
                             activeColor = if (useNewPlayerDesign) textButtonColor else textButtonColor.copy(alpha = 0.7f),
                             playerBackground = playerBackground,
-                            useDarkTheme = useDarkTheme
+                            useDarkTheme = sliderUseDarkTheme
                         ),
                         modifier = Modifier.padding(horizontal = PlayerHorizontalPadding),
                     )
@@ -1880,7 +2071,7 @@ fun BottomSheetPlayer(
                             colors = PlayerSliderColors.getSliderColors(
                                 activeColor = if (useNewPlayerDesign) textButtonColor else textButtonColor.copy(alpha = 0.7f),
                                 playerBackground = playerBackground,
-                                useDarkTheme = useDarkTheme
+                                useDarkTheme = sliderUseDarkTheme
                             ),
                             isPlaying = effectiveIsPlaying,
                         )
@@ -1906,7 +2097,7 @@ fun BottomSheetPlayer(
                             colors = PlayerSliderColors.getSliderColors(
                                 activeColor = if (useNewPlayerDesign) textButtonColor else textButtonColor.copy(alpha = 0.7f),
                                 playerBackground = playerBackground,
-                                useDarkTheme = useDarkTheme
+                                useDarkTheme = sliderUseDarkTheme
                             ),
                             modifier = Modifier.padding(horizontal = PlayerHorizontalPadding),
                             isPlaying = effectiveIsPlaying
@@ -1961,7 +2152,7 @@ fun BottomSheetPlayer(
                                 colors = PlayerSliderColors.getSliderColors(
                                     activeColor = if (useNewPlayerDesign) textButtonColor else textButtonColor.copy(alpha = 0.7f),
                                     playerBackground = playerBackground,
-                                    useDarkTheme = useDarkTheme
+                                    useDarkTheme = sliderUseDarkTheme
                                 )
                             )
                         },

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Queue.kt
@@ -1484,7 +1484,7 @@ private fun PlayerQueueButton(
                 iconButtonColor
             } else {
                 when (playerBackground) {
-                    PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH ->
+                    PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH, PlayerBackgroundStyle.AMBIENT_FADE ->
                         Color.White
                     PlayerBackgroundStyle.DEFAULT ->
                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Thumbnail.kt
@@ -6,6 +6,9 @@
 package com.music.vivi.ui.player
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.isSystemInDarkTheme
+import com.music.vivi.constants.DarkModeKey
+import com.music.vivi.ui.screens.settings.DarkMode
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -91,6 +94,7 @@ import com.music.vivi.constants.HidePlayerThumbnailKey
 import com.music.vivi.constants.ShowPlayerThumbnailShadowKey
 import com.music.vivi.constants.PlayerBackgroundStyle
 import com.music.vivi.constants.PlayerBackgroundStyleKey
+import com.music.vivi.constants.FollowColorThemeKey
 import com.music.vivi.constants.PlayerHorizontalPadding
 import com.music.vivi.constants.RotatingThumbnailKey
 import com.music.vivi.constants.SeekExtraSeconds
@@ -209,15 +213,17 @@ private fun getMediaItems(
     return MediaItemsData(items, currentMediaIndex)
 }
 
-/**
- * Get text color based on player background style.
- * Computed once per background style change.
- */
 @Stable
 @Composable
 private fun getTextColor(playerBackground: PlayerBackgroundStyle): Color {
+    val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
+    val useDarkTheme = if (darkTheme == DarkMode.AUTO) isSystemInDarkTheme() else darkTheme == DarkMode.ON
+    val followColorTheme by rememberPreference(FollowColorThemeKey, defaultValue = false)
     return when (playerBackground) {
         PlayerBackgroundStyle.DEFAULT -> MaterialTheme.colorScheme.onBackground
+        PlayerBackgroundStyle.AMBIENT_FADE -> {
+            if (followColorTheme && !useDarkTheme) MaterialTheme.colorScheme.onBackground else Color.White
+        }
         PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH -> Color.White
     }
 }

--- a/app/src/main/kotlin/com/music/vivi/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/screens/settings/AppearanceSettings.kt
@@ -110,6 +110,7 @@ import com.music.vivi.constants.ThumbnailCornerRadiusKey
 import com.music.vivi.constants.UseNewMiniPlayerDesignKey
 import com.music.vivi.constants.UseNewPlayerDesignKey
 import com.music.vivi.constants.UseExpressiveAlbumDesignKey
+import com.music.vivi.constants.FollowColorThemeKey
 import com.music.vivi.constants.ExpressiveSongAlbumImageKey
 import com.music.vivi.ui.component.ThumbnailCornerRadiusModal
 import com.music.vivi.ui.component.DefaultDialog
@@ -235,6 +236,10 @@ fun AppearanceSettings(
             MiniPlayerBackgroundStyleKey,
             defaultValue = PlayerBackgroundStyle.DEFAULT,
         )
+    val (followColorTheme, onFollowColorThemeChange) = rememberPreference(
+        FollowColorThemeKey,
+        defaultValue = false
+    )
 
     val (defaultOpenTab, onDefaultOpenTabChange) = rememberEnumPreference(
         DefaultOpenTabKey,
@@ -628,6 +633,7 @@ fun AppearanceSettings(
                     PlayerBackgroundStyle.GLOW_ANIMATED -> stringResource(R.string.glow_animated)
                     PlayerBackgroundStyle.APPLE_MUSIC -> stringResource(R.string.apple_music)
                     PlayerBackgroundStyle.LIVE_MESH -> stringResource(R.string.live_mesh)
+                    PlayerBackgroundStyle.AMBIENT_FADE -> stringResource(R.string.ambient_fade)
                 }
             }
         )
@@ -650,6 +656,7 @@ fun AppearanceSettings(
                     PlayerBackgroundStyle.BLUR -> stringResource(R.string.player_background_blur)
                     PlayerBackgroundStyle.GLOW_ANIMATED -> stringResource(R.string.glow_animated)
                     PlayerBackgroundStyle.LIVE_MESH -> stringResource(R.string.live_mesh)
+                    PlayerBackgroundStyle.AMBIENT_FADE -> stringResource(R.string.ambient_fade)
                     else -> ""
                 }
             }
@@ -1195,6 +1202,7 @@ fun AppearanceSettings(
                                     PlayerBackgroundStyle.BLUR -> stringResource(R.string.player_background_blur)
                                     PlayerBackgroundStyle.GLOW_ANIMATED -> stringResource(R.string.glow_animated)
                                     PlayerBackgroundStyle.LIVE_MESH -> stringResource(R.string.live_mesh)
+                                    PlayerBackgroundStyle.AMBIENT_FADE -> stringResource(R.string.ambient_fade)
                                     else -> stringResource(R.string.follow_theme)
                                 }
                             )
@@ -1275,12 +1283,38 @@ fun AppearanceSettings(
                                 PlayerBackgroundStyle.GLOW_ANIMATED -> stringResource(R.string.glow_animated)
                                 PlayerBackgroundStyle.APPLE_MUSIC -> stringResource(R.string.apple_music)
                                 PlayerBackgroundStyle.LIVE_MESH -> stringResource(R.string.live_mesh)
+                                PlayerBackgroundStyle.AMBIENT_FADE -> stringResource(R.string.ambient_fade)
                             }
                         )
                     },
                     onClick = { showPlayerBackgroundDialog = true },
                     isExpressive = true
                 ),
+                if (playerBackground == PlayerBackgroundStyle.AMBIENT_FADE) {
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.palette),
+                        title = { Text(stringResource(R.string.follow_color_theme)) },
+                        description = { Text(stringResource(R.string.follow_color_theme_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = followColorTheme,
+                                onCheckedChange = onFollowColorThemeChange,
+                                thumbContent = {
+                                    Icon(
+                                        painter = painterResource(
+                                            id = if (followColorTheme) R.drawable.check else R.drawable.close
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize)
+                                    )
+                                }
+                            )
+                        },
+                        onClick = { onFollowColorThemeChange(!followColorTheme) },
+                        isExpressive = true,
+                        descriptionBelow = true
+                    )
+                } else null,
                 Material3SettingsItem(
                     icon = painterResource(R.drawable.hide_image),
                     title = { Text(stringResource(R.string.hide_player_thumbnail)) },

--- a/app/src/main/kotlin/com/music/vivi/ui/theme/PlayerSliderColors.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/theme/PlayerSliderColors.kt
@@ -42,6 +42,13 @@ object PlayerSliderColors {
                     MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
                 }
             }
+            PlayerBackgroundStyle.AMBIENT_FADE -> {
+                if (useDarkTheme) {
+                    Color.White.copy(alpha = 0.4f)
+                } else {
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                }
+            }
             PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT, PlayerBackgroundStyle.GLOW_ANIMATED, PlayerBackgroundStyle.APPLE_MUSIC, PlayerBackgroundStyle.LIVE_MESH -> {
                 Color.White.copy(alpha = 0.4f)
             }

--- a/app/src/main/res/values/vivi_strings.xml
+++ b/app/src/main/res/values/vivi_strings.xml
@@ -167,6 +167,9 @@
     <string name="album_settings">Album Settings</string>
     <string name="new_mini_player_design">New mini player design</string>
     <string name="player_background_blur">Blur</string>
+    <string name="ambient_fade">Ambient Fade</string>
+    <string name="follow_color_theme">Follow color theme</string>
+    <string name="follow_color_theme_desc">Adapt player background based on light/dark mode</string>
     <string name="player_buttons_style">Player button colors</string>
     <string name="default_style">Default</string>
     <string name="primary_color_style">Primary color</string>


### PR DESCRIPTION
feat(player): add ambient fade player background style with theme adaptation

- Introduces a new "Ambient Fade" background style for the player and mini-player that dynamically displays shifting, blurred colors from the current album art.
- Adds a "Follow color theme" setting to adapt the background color palette and brightness to match the application's light or dark mode.
- Exposes user preferences for the new style and theme adaptation directly within the Appearance settings screen.

## 🚀 What does this PR do?
- [ ] 🐛 Fixes a bug (Issue #___)
- [x] ✨ Adds a new feature
- [x] 🎨 UI/Design update
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code refactoring

## 📸 Screenshots / Recordings
Settings :
<img width="1080" height="544" alt="Screenshot_2026-07-12-23-52-42-17_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/c1111d73-bcb8-4833-b60a-88ba0c8cf6a9" />

Light vs Dark mode : 
| | Light | Dark |
|--|-----|-----|
| Full screen | <img width="1080" height="2400" alt="Screenshot_2026-07-12-22-45-46-18_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/0cce459e-ad86-4352-8ad6-383e1be92208" /> | <img width="1080" height="2400" alt="Screenshot_2026-07-12-23-09-57-85_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/a41da31c-43bd-411b-b149-afff2290b041" /> |
| Mini player | <img width="1080" height="370" alt="Screenshot_2026-07-12-23-11-07-98_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/7baec21c-1637-422b-8be5-cdf84da126e9" /> | <img width="1080" height="411" alt="IMG_20260713_000901" src="https://github.com/user-attachments/assets/1e24e790-222d-4165-b52f-b6e46acc4608" /> |

Few More  screenshots
|<img width="1080" height="2400" alt="Screenshot_2026-07-12-22-52-40-68_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/31805792-9cb7-4442-abda-64003eb2c86e" /> | <img width="1080" height="2400" alt="Screenshot_2026-07-13-00-22-28-74_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/7be5ded0-d57a-42f3-b6d4-19c16203d3c2" /> | <img width="1080" height="2400" alt="Screenshot_2026-07-13-00-22-49-99_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/5527f5d6-8153-4d59-a85a-da675f9af4b9" /> | <img width="1080" height="2400" alt="Screenshot_2026-07-12-23-20-14-50_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/e64d0648-d276-4fd8-9b37-f3aeec224a52" /> | <img width="1080" height="2400" alt="Screenshot_2026-07-13-00-25-41-84_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/eca3d9e9-c78c-4746-b029-1277245522e1" /> | <img width="1080" height="2400" alt="Screenshot_2026-07-13-00-25-30-72_2570d5fd1b6f278acf59015f20d0c71d" src="https://github.com/user-attachments/assets/2d6beeab-5ff9-4f71-8e71-5d7db5b40638" /> | 
|-|-|-|-|-|-|

## 🛠️ Checklist




- [x] My code follows the project's style guidelines.
- [x] I have tested my changes on an Android device/emulator.
- [x] I have verified that no new warnings/errors are introduced.
- [x] I have updated the documentation (if necessary).

## 📝 Additional Notes
- **Follow color theme** is conditionally shown when player background style  is set to  **Ambient fade**