### PR TITLE
Updated the "Slim" player style for small devices by reducing extra space

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
@@ -1333,7 +1333,7 @@ fun BottomSheetPlayer(
         // (see the ORIENTATION_LANDSCAPE branch below) - used to hide the redundant small
         // thumbnail that normally sits next to the title in the compact controls row.
         val isTabletLandscapeWithBigThumbnail = LocalConfiguration.current.let {
-            it.screenWidthDp >= 600 &&
+            it.smallestScreenWidthDp >= 600 &&
                 it.orientation == Configuration.ORIENTATION_LANDSCAPE &&
                 showInlineLyrics
         }

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
@@ -174,12 +174,15 @@ import com.music.vivi.constants.PlayerBackgroundStyleKey
 import com.music.vivi.constants.PlayerButtonsStyle
 import com.music.vivi.constants.PlayerButtonsStyleKey
 import com.music.vivi.constants.PlayerHorizontalPadding
+import com.music.vivi.constants.PlayerThumbnailShadowElevationKey
 import com.music.vivi.constants.QueuePeekHeight
+import com.music.vivi.constants.ShowPlayerThumbnailShadowKey
 import com.music.vivi.constants.SliderStyle
 import com.music.vivi.constants.SliderStyleKey
 import com.music.vivi.constants.SquigglySliderKey
 import com.music.vivi.constants.SwipeLyricsKey
 import com.music.vivi.constants.ThumbnailCornerRadius
+import com.music.vivi.constants.ThumbnailCornerRadiusKey
 import com.music.vivi.constants.UseNewPlayerDesignKey
 import com.music.vivi.constants.ShowAudioQualityBadgeKey
 import com.music.vivi.db.entities.LyricsEntity
@@ -1326,6 +1329,15 @@ fun BottomSheetPlayer(
             )
         },
     ) {
+        // True when we're showing the large tablet-landscape thumbnail above the controls
+        // (see the ORIENTATION_LANDSCAPE branch below) - used to hide the redundant small
+        // thumbnail that normally sits next to the title in the compact controls row.
+        val isTabletLandscapeWithBigThumbnail = LocalConfiguration.current.let {
+            it.screenWidthDp >= 600 &&
+                it.orientation == Configuration.ORIENTATION_LANDSCAPE &&
+                showInlineLyrics
+        }
+
         val controlsContent: @Composable ColumnScope.(MediaMetadata) -> Unit = { mediaMetadata ->
             val playPauseRoundness by animateDpAsState(
                 targetValue = if (isPlaying) 24.dp else 36.dp,
@@ -1345,7 +1357,7 @@ fun BottomSheetPlayer(
                     targetState = showInlineLyrics,
                     label = "ThumbnailAnimation"
                 ) { showLyrics ->
-                    if (showLyrics) {
+                    if (showLyrics && !isTabletLandscapeWithBigThumbnail) {
                         Row {
                             if (hidePlayerThumbnail) {
                                 Box(
@@ -2614,19 +2626,41 @@ fun BottomSheetPlayer(
 
                         // On tablets, the compact controls row (56dp thumbnail) looks
                         // too small next to the lyrics panel, so show a large album art
-                        // thumbnail above it instead.
-                        val isTabletScreen = LocalConfiguration.current.screenWidthDp >= 600
-                        if (isTabletScreen && showInlineLyrics) {
+                        // thumbnail above it instead - styled the same way (corner radius,
+                        // shadow) as the regular non-lyrics thumbnail.
+                        val isTabletScreen = isTabletLandscapeWithBigThumbnail
+                        if (isTabletScreen) {
+                            val bigThumbnailCornerRadius by rememberPreference(ThumbnailCornerRadiusKey, defaultValue = 3f)
+                            val showBigThumbnailShadow by rememberPreference(ShowPlayerThumbnailShadowKey, defaultValue = false)
+                            val bigThumbnailShadowElevation by rememberPreference(PlayerThumbnailShadowElevationKey, defaultValue = 8f)
+                            val bigThumbnailShape = RoundedCornerShape(bigThumbnailCornerRadius.dp * 2)
+
                             mediaMetadata?.let {
-                                AsyncImage(
-                                    model = it.thumbnailUrl,
-                                    contentDescription = null,
-                                    contentScale = if (cropAlbumArt) ContentScale.Crop else ContentScale.Fit,
+                                Box(
                                     modifier = Modifier
                                         .fillMaxWidth(0.7f)
                                         .aspectRatio(1f)
-                                        .clip(RoundedCornerShape(ThumbnailCornerRadius))
-                                )
+                                        .then(
+                                            if (showBigThumbnailShadow) {
+                                                Modifier.customSoftShadow(
+                                                    elevation = bigThumbnailShadowElevation.dp,
+                                                    cornerRadius = bigThumbnailCornerRadius.dp * 2,
+                                                    enabled = true
+                                                )
+                                            } else {
+                                                Modifier
+                                            }
+                                        )
+                                ) {
+                                    AsyncImage(
+                                        model = it.thumbnailUrl,
+                                        contentDescription = null,
+                                        contentScale = if (cropAlbumArt) ContentScale.Crop else ContentScale.Fit,
+                                        modifier = Modifier
+                                            .fillMaxSize()
+                                            .clip(bigThumbnailShape)
+                                    )
+                                }
                                 Spacer(Modifier.height(24.dp))
                             }
                         }

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
@@ -78,6 +78,7 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.ProvideTextStyle
@@ -87,6 +88,7 @@ import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -1929,44 +1931,46 @@ fun BottomSheetPlayer(
                         label = "trackHeight"
                     )
 
-                    Slider(
-                        value = (sliderPosition ?: effectivePosition).toFloat(),
-                        valueRange = 0f..(if (duration == C.TIME_UNSET) 0f else duration.toFloat()),
-                        onValueChange = {
-                            if (!isListenTogetherGuest) {
-                                sliderPosition = it.toLong()
-                            }
-                        },
-                        onValueChangeFinished = {
-                            if (!isListenTogetherGuest) {
-                                sliderPosition?.let {
-                                    if (isCasting) {
-                                        castHandler?.seekTo(it)
-                                        lastManualSeekTime = System.currentTimeMillis()
-                                    } else {
-                                        playerConnection.player.seekTo(it)
-                                    }
-                                    position = it
+                    CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides 0.dp) {
+                        Slider(
+                            value = (sliderPosition ?: effectivePosition).toFloat(),
+                            valueRange = 0f..(if (duration == C.TIME_UNSET) 0f else duration.toFloat()),
+                            onValueChange = {
+                                if (!isListenTogetherGuest) {
+                                    sliderPosition = it.toLong()
                                 }
-                                sliderPosition = null
-                            }
-                        },
-                        enabled = !isListenTogetherGuest,
-                        interactionSource = trackInteractionSource,
-                        thumb = { Spacer(modifier = Modifier.size(0.dp)) },
-                        track = { sliderState ->
-                            PlayerSliderTrack(
-                                sliderState = sliderState,
-                                trackHeight = trackHeight,
-                                colors = PlayerSliderColors.getSliderColors(
-                                    activeColor = if (useNewPlayerDesign) textButtonColor else textButtonColor.copy(alpha = 0.7f),
-                                    playerBackground = playerBackground,
-                                    useDarkTheme = useDarkTheme
+                            },
+                            onValueChangeFinished = {
+                                if (!isListenTogetherGuest) {
+                                    sliderPosition?.let {
+                                        if (isCasting) {
+                                            castHandler?.seekTo(it)
+                                            lastManualSeekTime = System.currentTimeMillis()
+                                        } else {
+                                            playerConnection.player.seekTo(it)
+                                        }
+                                        position = it
+                                    }
+                                    sliderPosition = null
+                                }
+                            },
+                            enabled = !isListenTogetherGuest,
+                            interactionSource = trackInteractionSource,
+                            thumb = { Spacer(modifier = Modifier.size(0.dp)) },
+                            track = { sliderState ->
+                                PlayerSliderTrack(
+                                    sliderState = sliderState,
+                                    trackHeight = trackHeight,
+                                    colors = PlayerSliderColors.getSliderColors(
+                                        activeColor = if (useNewPlayerDesign) textButtonColor else textButtonColor.copy(alpha = 0.7f),
+                                        playerBackground = playerBackground,
+                                        useDarkTheme = useDarkTheme
+                                    )
                                 )
-                            )
-                        },
-                        modifier = Modifier.padding(horizontal = PlayerHorizontalPadding)
-                    )
+                            },
+                            modifier = Modifier.padding(horizontal = PlayerHorizontalPadding)
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
@@ -61,6 +61,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.add
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
@@ -2610,6 +2611,25 @@ fun BottomSheetPlayer(
                             .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
                     ) {
                         Spacer(Modifier.weight(1f))
+
+                        // On tablets, the compact controls row (56dp thumbnail) looks
+                        // too small next to the lyrics panel, so show a large album art
+                        // thumbnail above it instead.
+                        val isTabletScreen = LocalConfiguration.current.screenWidthDp >= 600
+                        if (isTabletScreen && showInlineLyrics) {
+                            mediaMetadata?.let {
+                                AsyncImage(
+                                    model = it.thumbnailUrl,
+                                    contentDescription = null,
+                                    contentScale = if (cropAlbumArt) ContentScale.Crop else ContentScale.Fit,
+                                    modifier = Modifier
+                                        .fillMaxWidth(0.7f)
+                                        .aspectRatio(1f)
+                                        .clip(RoundedCornerShape(ThumbnailCornerRadius))
+                                )
+                                Spacer(Modifier.height(24.dp))
+                            }
+                        }
 
                         mediaMetadata?.let {
                             controlsContent(it)

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Player.kt
@@ -232,6 +232,7 @@ import android.view.TextureView
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -2618,7 +2619,14 @@ fun BottomSheetPlayer(
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
-                            .weight(if (showInlineLyrics) 0.65f else 1f, false)
+                            .weight(
+                                when {
+                                    isTabletLandscapeWithBigThumbnail -> 0.9f
+                                    showInlineLyrics -> 0.65f
+                                    else -> 1f
+                                },
+                                false
+                            )
                             .animateContentSize()
                             .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
                     ) {
@@ -2665,8 +2673,23 @@ fun BottomSheetPlayer(
                             }
                         }
 
-                        mediaMetadata?.let {
-                            controlsContent(it)
+                        if (isTabletScreen) {
+                            val baseDensity = LocalDensity.current
+                            val controlsScale = 1.35f
+                            CompositionLocalProvider(
+                                LocalDensity provides Density(
+                                    density = baseDensity.density * controlsScale,
+                                    fontScale = baseDensity.fontScale
+                                )
+                            ) {
+                                mediaMetadata?.let {
+                                    controlsContent(it)
+                                }
+                            }
+                        } else {
+                            mediaMetadata?.let {
+                                controlsContent(it)
+                            }
                         }
 
                         Spacer(Modifier.weight(1f))


### PR DESCRIPTION
Optimized "Slim" player slider style for small device size by reducing the extra space above and below the player style. Previously, the thumbnail and shadow were being cut a bit when any bluetooth device is connected. Now it has been optimized and the thumbnail and shadow are properly visible.

## 🚀 What does this PR do?
- [✅] 🎨 UI/Design update

## 📸 Screenshots / Recordings
<img width="994" height="2154" alt="current player" src="https://github.com/user-attachments/assets/0aaab0cd-4204-4c92-b5e8-07bcfcc1c06f" />
Current Slim player style 👆
<img width="995" height="2155" alt="Updated player" src="https://github.com/user-attachments/assets/faf295c9-652b-4508-91e9-40f8257a24e5" />
Updated Slim player style 👆

## 🛠️ Checklist
- [✅] My code follows the project's style guidelines.
- [✅] I have tested my changes on an Android device/emulator.
- [✅] I have verified that no new warnings/errors are introduced.

