### PR TITLE
feat(lyrics): add word-sync priority lyrics fetching strategy

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
@@ -96,6 +96,7 @@ val EnableSimpMusicKey = booleanPreferencesKey("enableSimpMusic")
 
 val EnableYouLyPlusKey = booleanPreferencesKey("enableYouLyPlus")
 val EnablePaxsenixKey = booleanPreferencesKey("enablePaxsenix")
+val UseWordSyncPriorityFetchKey = booleanPreferencesKey("useWordSyncPriorityFetch")
 val HideExplicitKey = booleanPreferencesKey("hideExplicit")
 val HideVideoSongsKey = booleanPreferencesKey("hideVideoSongs")
 val HideYoutubeShortsKey = booleanPreferencesKey("hideYoutubeShorts")

--- a/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
@@ -253,7 +253,7 @@ val AddToPlaylistSortDescendingKey = booleanPreferencesKey("addToPlaylistSortDes
 val ArtistSongSortTypeKey = stringPreferencesKey("artistSongSortType")
 val ArtistSongSortDescendingKey = booleanPreferencesKey("artistSongSortDescending")
 val MixSortTypeKey = stringPreferencesKey("mixSortType")
-val MixSortDescendingKey = booleanPreferencesKey("albumSortDescending")
+val MixSortDescendingKey = booleanPreferencesKey("mixSortDescending")
 
 val SongFilterKey = stringPreferencesKey("songFilter")
 val ArtistFilterKey = stringPreferencesKey("artistFilter")
@@ -313,6 +313,14 @@ enum class SongFilter {
 enum class ArtistFilter {
     LIBRARY,
     LIKED
+}
+
+val ArtistSourceFilterKey = stringPreferencesKey("artistSourceFilter")
+
+enum class ArtistSourceFilter {
+    ALL,
+    LOCAL,
+    YOUTUBE
 }
 
 enum class AlbumFilter {

--- a/app/src/main/kotlin/com/music/vivi/lyrics/KuGouLyricsProvider.kt
+++ b/app/src/main/kotlin/com/music/vivi/lyrics/KuGouLyricsProvider.kt
@@ -13,6 +13,7 @@ import com.music.vivi.utils.get
 
 object KuGouLyricsProvider : LyricsProvider {
     override val name = "Kugou"
+    override val supportsWordSync = false
     override fun isEnabled(context: Context): Boolean =
         context.dataStore[EnableKugouKey] ?: true
 

--- a/app/src/main/kotlin/com/music/vivi/lyrics/LrcLibLyricsProvider.kt
+++ b/app/src/main/kotlin/com/music/vivi/lyrics/LrcLibLyricsProvider.kt
@@ -13,6 +13,7 @@ import com.music.vivi.utils.get
 
 object LrcLibLyricsProvider : LyricsProvider {
     override val name = "LrcLib"
+    override val supportsWordSync = false
 
     override fun isEnabled(context: Context): Boolean = context.dataStore[EnableLrcLibKey] ?: true
 

--- a/app/src/main/kotlin/com/music/vivi/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/com/music/vivi/lyrics/LyricsHelper.kt
@@ -30,6 +30,13 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
+import com.music.vivi.constants.UseWordSyncPriorityFetchKey
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.atomic.AtomicInteger
 
 @Singleton
 class LyricsHelper
@@ -69,6 +76,36 @@ constructor(
     private val activeFetches = mutableMapOf<String, Deferred<LyricsWithProvider>>()
     private val fetchesMutex = Mutex()
 
+    /**
+     * Per-provider failure tracking so a provider that's currently rate-limited
+     * or down doesn't get retried on every single song lookup. After
+     * [FAILURE_THRESHOLD] consecutive failures, a provider "sits out" for
+     * [COOLDOWN_MS] before it's tried again. A single success resets its count.
+     */
+    private data class ProviderHealth(var consecutiveFailures: Int = 0, var cooldownUntil: Long = 0L)
+    private val providerHealth = java.util.concurrent.ConcurrentHashMap<String, ProviderHealth>()
+
+    private fun isProviderCoolingDown(providerName: String): Boolean {
+        val health = providerHealth[providerName] ?: return false
+        return System.currentTimeMillis() < health.cooldownUntil
+    }
+
+    private fun recordProviderSuccess(providerName: String) {
+        providerHealth.getOrPut(providerName) { ProviderHealth() }.consecutiveFailures = 0
+    }
+
+    private fun recordProviderFailure(providerName: String) {
+        val health = providerHealth.getOrPut(providerName) { ProviderHealth() }
+        synchronized(health) {
+            health.consecutiveFailures++
+            if (health.consecutiveFailures >= FAILURE_THRESHOLD) {
+                health.cooldownUntil = System.currentTimeMillis() + COOLDOWN_MS
+                health.consecutiveFailures = 0
+            }
+        }
+    }
+
+
     suspend fun getLyrics(mediaMetadata: MediaMetadata): LyricsWithProvider {
         currentLyricsJob?.cancel()
 
@@ -95,29 +132,20 @@ constructor(
         val deferred = fetchesMutex.withLock {
             activeFetches.getOrPut(cacheKey) {
                 helperScope.async {
-                    val providers = resolveLyricsProviders()
-                    for (provider in providers) {
-                        if (provider.isEnabled(context)) {
-                            try {
-                                val result = provider.getLyrics(
-                                    mediaMetadata.id,
-                                    mediaMetadata.title,
-                                    mediaMetadata.artists.joinToString { it.name },
-                                    mediaMetadata.duration,
-                                    mediaMetadata.album?.title,
-                                )
-                                result.onSuccess { lyrics ->
-                                    return@async LyricsWithProvider(lyrics, provider.name)
-                                }.onFailure {
-                                    reportException(it)
-                                }
-                            } catch (e: Exception) {
-                                // Catch network-related exceptions like UnresolvedAddressException
-                                reportException(e)
-                            }
+                    try {
+                        val useWordSyncPriority = context.dataStore.data.first()[UseWordSyncPriorityFetchKey] ?: true
+                        if (useWordSyncPriority) {
+                            raceProviders(mediaMetadata)
+                        } else {
+                            sequentialProviders(mediaMetadata)
                         }
+                    } catch (e: Exception) {
+                        // Should not happen - both strategies are defensive internally -
+                        // but never let an unexpected exception here leave the caller
+                        // (and whatever UI state is awaiting it) stuck indefinitely.
+                        reportException(e)
+                        LyricsWithProvider(LYRICS_NOT_FOUND, "Unknown")
                     }
-                    LyricsWithProvider(LYRICS_NOT_FOUND, "Unknown")
                 }
             }
         }
@@ -130,6 +158,163 @@ constructor(
             }
         }
     }
+
+    
+    private suspend fun sequentialProviders(mediaMetadata: MediaMetadata): LyricsWithProvider {
+        val providers = resolveLyricsProviders()
+        for (provider in providers) {
+            if (provider.isEnabled(context)) {
+                try {
+                    val result = provider.getLyrics(
+                        mediaMetadata.id,
+                        mediaMetadata.title,
+                        mediaMetadata.artists.joinToString { it.name },
+                        mediaMetadata.duration,
+                        mediaMetadata.album?.title,
+                    )
+                    result.onSuccess { lyrics ->
+                        return LyricsWithProvider(lyrics, provider.name)
+                    }.onFailure {
+                        reportException(it)
+                    }
+                } catch (e: Exception) {
+                    // Catch network-related exceptions like UnresolvedAddressException
+                    reportException(e)
+                }
+            }
+        }
+        return LyricsWithProvider(LYRICS_NOT_FOUND, "Unknown")
+    }
+
+    private data class Candidate(
+        val lyrics: String,
+        val providerName: String,
+        val tier: Int,
+    )
+
+    
+    private suspend fun raceProviders(mediaMetadata: MediaMetadata): LyricsWithProvider = coroutineScope {
+        val providers = resolveLyricsProviders().filter { it.isEnabled(context) && !isProviderCoolingDown(it.name) }
+        if (providers.isEmpty()) {
+            return@coroutineScope LyricsWithProvider(LYRICS_NOT_FOUND, "Unknown")
+        }
+
+        val priorityIndex = providers.withIndex().associate { (index, provider) -> provider.name to index }
+        val results = Channel<Candidate>(Channel.UNLIMITED)
+
+        // Signals once every provider that could possibly return word-by-word
+        // data has finished (succeeded, failed, or timed out).
+        val wordCapableRemaining = AtomicInteger(providers.count { it.supportsWordSync })
+        val wordCapableDone = CompletableDeferred<Unit>()
+        if (wordCapableRemaining.get() == 0) wordCapableDone.complete(Unit)
+
+        val jobs = providers.map { provider ->
+            async {
+                try {
+
+                    val result = withTimeoutOrNull(PROVIDER_TIMEOUT_MS) {
+                        provider.getLyrics(
+                            mediaMetadata.id,
+                            mediaMetadata.title,
+                            mediaMetadata.artists.joinToString { it.name },
+                            mediaMetadata.duration,
+                            mediaMetadata.album?.title,
+                        )
+                    }
+                    if (result == null) {
+                        recordProviderFailure(provider.name)
+                    } else {
+                        result.onSuccess { lyrics ->
+                            recordProviderSuccess(provider.name)
+                            if (lyrics.isNotBlank()) {
+                                val tier = LyricsUtils.getSyncTier(lyrics)
+                                if (tier > LyricsUtils.TIER_PLAIN) {
+                                    results.trySend(Candidate(lyrics, provider.name, tier))
+                                }
+                            }
+                        }.onFailure {
+                            recordProviderFailure(provider.name)
+                            reportException(it)
+                        }
+                    }
+                } catch (e: Exception) {
+                    // Catch network-related exceptions like UnresolvedAddressException
+                    recordProviderFailure(provider.name)
+                    reportException(e)
+                } finally {
+                    if (provider.supportsWordSync && wordCapableRemaining.decrementAndGet() == 0) {
+                        wordCapableDone.complete(Unit)
+                    }
+                }
+            }
+        }
+
+
+        // Close the channel once every provider has finished, so the receive
+        // loop below ends on its own even if fewer results arrive than expected.
+        val closerJob = launch {
+            jobs.joinAll()
+            results.close()
+        }
+
+        var best: Candidate? = null
+        val overallDeadlineAt = System.currentTimeMillis() + OVERALL_TIMEOUT_MS
+        // Set when the first line-sync result arrives; word-sync providers then
+        // get at most WORD_SYNC_PATIENCE_MS to beat it before we give up waiting.
+        var wordSyncPatientUntil = Long.MAX_VALUE
+
+        try {
+            pollLoop@ while (true) {
+                val timeLeft = overallDeadlineAt - System.currentTimeMillis()
+                if (timeLeft <= 0) break@pollLoop
+
+                // We already have a usable result and either:
+                //  (a) every word-capable provider has finished, OR
+                //  (b) our patience window for word-sync has expired.
+                // Either way, stop waiting.
+                if (best != null && (wordCapableDone.isCompleted ||
+                            System.currentTimeMillis() >= wordSyncPatientUntil)) break@pollLoop
+
+                // Poll in short slices so we notice wordCapableDone completing
+                // without needing a full select expression.
+                val slice = minOf(POLL_SLICE_MS, timeLeft)
+                val received = withTimeoutOrNull(slice) { results.receiveCatching() }
+                if (received == null) continue@pollLoop // this slice timed out - loop back and re-check exit conditions
+                if (received.isClosed) break@pollLoop // channel drained - nothing more will ever arrive
+                val candidate = received.getOrNull() ?: continue@pollLoop
+
+                if (candidate.tier == LyricsUtils.TIER_WORD_SYNC) {
+                    best = candidate
+                    break@pollLoop // can't do better than word-by-word - stop immediately
+                }
+
+                // Line-sync result: record it and start the patience countdown so
+                // we don't wait the full 15 s for word-sync providers that clearly
+                // don't have this track.
+                val candidatePriority = priorityIndex[candidate.providerName] ?: Int.MAX_VALUE
+                val bestPriority = best?.let { priorityIndex[it.providerName] ?: Int.MAX_VALUE }
+                val candidateIsBetter = best == null ||
+                        candidate.tier > best.tier ||
+                        (candidate.tier == best.tier && candidatePriority < bestPriority!!)
+
+                if (candidateIsBetter) {
+                    best = candidate
+                    // Start patience window on the first line-sync result we accept.
+                    if (wordSyncPatientUntil == Long.MAX_VALUE) {
+                        wordSyncPatientUntil = System.currentTimeMillis() + WORD_SYNC_PATIENCE_MS
+                    }
+                }
+            }
+        } finally {
+            jobs.forEach { it.cancel() }
+            closerJob.cancel()
+            results.close()
+        }
+
+        best?.let { LyricsWithProvider(it.lyrics, it.providerName) }
+            ?: LyricsWithProvider(LYRICS_NOT_FOUND, "Unknown")
+    }
+
 
     suspend fun getAllLyrics(
         mediaId: String,
@@ -192,7 +377,13 @@ constructor(
     }
 
     companion object {
-        private const val MAX_CACHE_SIZE = 3
+        private const val MAX_CACHE_SIZE = 20
+        private const val FAILURE_THRESHOLD = 3
+        private const val COOLDOWN_MS = 60_000L
+        private const val POLL_SLICE_MS = 150L
+        private const val WORD_SYNC_PATIENCE_MS = 4_000L
+        private const val OVERALL_TIMEOUT_MS = 16_000L
+        private const val PROVIDER_TIMEOUT_MS = 8_000L
     }
 }
 

--- a/app/src/main/kotlin/com/music/vivi/lyrics/LyricsProvider.kt
+++ b/app/src/main/kotlin/com/music/vivi/lyrics/LyricsProvider.kt
@@ -12,6 +12,7 @@ interface LyricsProvider {
 
     fun isEnabled(context: Context): Boolean
 
+    val supportsWordSync: Boolean get() = true
     suspend fun getLyrics(
         id: String,
         title: String,

--- a/app/src/main/kotlin/com/music/vivi/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/com/music/vivi/lyrics/LyricsUtils.kt
@@ -344,6 +344,22 @@ object LyricsUtils {
             .replace("&nbsp;", " ")
             .replace("&amp;", "&")
 
+    fun getSyncTier(lyrics: String): Int {
+        if (lyrics.isBlank()) return 0
+        val parsed = try {
+            parseLyrics(lyrics)
+        } catch (e: Exception) {
+            emptyList()
+        }
+        if (parsed.isEmpty()) return 0 // no [mm:ss.xx] tags matched -> plain text
+        val hasWordTimings = parsed.any { !it.words.isNullOrEmpty() }
+        return if (hasWordTimings) TIER_WORD_SYNC else TIER_LINE_SYNC
+    }
+
+    const val TIER_PLAIN = 0
+    const val TIER_LINE_SYNC = 1
+    const val TIER_WORD_SYNC = 2
+
     fun parseLyrics(lyrics: String): List<LyricsEntry> {
         // Unescape JSON string if needed
         val unescapedLyrics = lyrics

--- a/app/src/main/kotlin/com/music/vivi/lyrics/YouTubeLyricsProvider.kt
+++ b/app/src/main/kotlin/com/music/vivi/lyrics/YouTubeLyricsProvider.kt
@@ -11,6 +11,7 @@ import com.music.innertube.models.WatchEndpoint
 
 object YouTubeLyricsProvider : LyricsProvider {
     override val name = "YouTube Music"
+    override val supportsWordSync = false
 
     override fun isEnabled(context: Context) = true
 

--- a/app/src/main/kotlin/com/music/vivi/lyrics/YouTubeSubtitleLyricsProvider.kt
+++ b/app/src/main/kotlin/com/music/vivi/lyrics/YouTubeSubtitleLyricsProvider.kt
@@ -10,6 +10,7 @@ import com.music.innertube.YouTube
 
 object YouTubeSubtitleLyricsProvider : LyricsProvider {
     override val name = "YouTube Subtitle"
+    override val supportsWordSync = false
 
     override fun isEnabled(context: Context) = true
 

--- a/app/src/main/kotlin/com/music/vivi/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/screens/settings/ContentSettings.kt
@@ -115,6 +115,8 @@ import com.music.vivi.utils.PlaybackLogManager
 import com.music.vivi.ui.component.PlaybackLogsDialog
 import androidx.compose.runtime.collectAsState
 import java.net.Proxy
+import com.music.vivi.constants.UseWordSyncPriorityFetchKey
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -152,6 +154,10 @@ fun ContentSettings(
     val (enableSimpMusic, onEnableSimpMusicChange) = rememberPreference(key = EnableSimpMusicKey, defaultValue = true)
     val (enableYouLyPlus, onEnableYouLyPlusChange) = rememberPreference(key = EnableYouLyPlusKey, defaultValue = true)
     val (enablePaxsenix, onEnablePaxsenixChange) = rememberPreference(key = EnablePaxsenixKey, defaultValue = true)
+    val (useWordSyncPriorityFetch, onUseWordSyncPriorityFetchChange) = rememberPreference(
+        key = UseWordSyncPriorityFetchKey,
+        defaultValue = true,
+    )
     val (lyricsProviderOrder, onLyricsProviderOrderChange) = rememberPreference(
         key = LyricsProviderOrderKey,
         defaultValue = "",
@@ -1114,6 +1120,29 @@ fun ContentSettings(
                     title = { Text(stringResource(R.string.lyrics_provider_priority)) },
                     description = { Text(stringResource(R.string.lyrics_provider_priority_desc)) },
                     onClick = { showProviderPriorityDialog = true },
+                    isExpressive = true,
+                    descriptionBelow = true	
+                ),
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.lyrics),
+                    title = { Text(stringResource(R.string.use_word_sync_priority_fetch)) },
+                    description = { Text(stringResource(R.string.use_word_sync_priority_fetch_desc)) },
+                    trailingContent = {
+                        Switch(
+                            checked = useWordSyncPriorityFetch,
+                            onCheckedChange = onUseWordSyncPriorityFetchChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (useWordSyncPriorityFetch) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize)
+                                )
+                            }
+                        )
+                    },
+                    onClick = { onUseWordSyncPriorityFetchChange(!useWordSyncPriorityFetch) },
                     isExpressive = true,
                     descriptionBelow = true
                 ),

--- a/app/src/main/res/values/vivi_strings.xml
+++ b/app/src/main/res/values/vivi_strings.xml
@@ -959,6 +959,8 @@
     <string name="no_playback_logs">No playback events recorded yet</string>
     <string name="show_comment_button">Show comment button</string>
     <string name="show_comment_button_description">Show a button to view comments in the player queue</string>
+    <string name="use_word_sync_priority_fetch">Word-by-word priority fetching</string>
+    <string name="use_word_sync_priority_fetch_desc">Prioritize providers that offer word-synced lyrics timing</string>
     <string name="build_stable">STABLE</string>
     <string name="build_nightly">NIGHTLY</string>
     <string name="jiosaavn_settings">JioSaavn Settings</string>


### PR DESCRIPTION
## 🚀 What does this PR do?
- [ ] 🐛 Fixes a bug (Issue #___)
- [x] ✨ Adds a new feature
- [x] 🎨 UI/Design update
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code refactoring

## 📸 Screenshots / Recordings
<img width="1220" height="2712" alt="Screenshot_20260726-224504_VIVI" src="https://github.com/user-attachments/assets/4f5776de-9a9b-416d-9811-d05625b8f7c9" />

## 🛠️ Checklist
- [x] My code follows the project's style guidelines.
- [x] I have tested my changes on an Android device/emulator.
- [x] I have verified that no new warnings/errors are introduced.
- [ ] I have updated the documentation (if necessary).

## 📝 Additional Notes
Adds an optional lyrics-fetching strategy that queries every enabled
provider concurrently instead of one at a time, and prioritizes
word-by-word synced results over line-only ones. Off by default is
not the case here - defaults to on, matching the toggle's own
default in Content Settings; the original sequential strategy is
still available and can be switched back to at any time.

Key points:
- Providers are split into word-sync-capable (BetterLyrics, PaxSenix,
  Musixmatch, SimpMusic, YouLyPlus) vs line-only (LrcLib, KuGou,
  YouTube Subtitle, YouTube Music) via a new supportsWordSync flag.
- Each result is verified via getSyncTier() rather than trusting a
  provider's capability alone - a word-capable provider that only
  returns line-level data for a given track is treated accordingly.
- A word-by-word result wins immediately; a line-only result waits
  briefly (up to a 4s patience window) for word-capable providers
  still in flight before settling.
- Each provider is capped at 8s so a stuck/slow provider can't stall
  the whole search, with a 16s overall ceiling as a final safety net.
- Includes a per-provider failure cooldown (3 consecutive failures
  -> 60s cooldown) to avoid hammering a provider that's rate-limited
  or down.
- Lyrics cache bumped from 3 to 20 entries.