### PR TITLE
fix(auth): fix Brand Account login

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/App.kt
+++ b/app/src/main/kotlin/com/music/vivi/App.kt
@@ -34,6 +34,7 @@ import com.music.vivi.extensions.toInetSocketAddress
 import com.music.vivi.utils.CrashHandler
 import com.music.vivi.utils.ViviPrefCache
 import com.music.vivi.utils.dataStore
+import com.music.vivi.utils.normalizeDataSyncId
 import com.music.vivi.utils.reportException
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
@@ -173,11 +174,7 @@ class App : Application(), SingletonImageLoader.Factory {
                 .map { it[DataSyncIdKey] }
                 .distinctUntilChanged()
                 .collect { dataSyncId ->
-                    YouTube.dataSyncId = dataSyncId?.let {
-                        it.takeIf { !it.contains("||") }
-                            ?: it.takeIf { it.endsWith("||") }?.substringBefore("||")
-                            ?: it.substringAfter("||")
-                    }
+                    YouTube.dataSyncId = normalizeDataSyncId(dataSyncId)
                 }
         }
 

--- a/app/src/main/kotlin/com/music/vivi/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/screens/LoginScreen.kt
@@ -41,6 +41,7 @@ import com.music.vivi.constants.InnerTubeCookieKey
 import com.music.vivi.constants.VisitorDataKey
 import com.music.vivi.ui.component.IconButton
 import com.music.vivi.ui.utils.backToMain
+import com.music.vivi.utils.normalizeDataSyncId
 import com.music.vivi.utils.rememberPreference
 import com.music.vivi.utils.reportException
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -87,7 +88,7 @@ fun LoginScreen(
 
                                 // Initialize YouTube object with new authentication data
                                 YouTube.cookie = innerTubeCookie
-                                YouTube.dataSyncId = dataSyncId
+                                YouTube.dataSyncId = normalizeDataSyncId(dataSyncId)
                                 YouTube.visitorData = visitorData
 
                                 Timber.d("Login: YouTube object initialized, validating...")
@@ -137,7 +138,7 @@ fun LoginScreen(
                     @JavascriptInterface
                     fun onRetrieveDataSyncId(newDataSyncId: String?) {
                         if (newDataSyncId != null) {
-                            dataSyncId = newDataSyncId.substringBefore("||")
+                            dataSyncId = newDataSyncId
                         }
                     }
                 }, "Android")

--- a/app/src/main/kotlin/com/music/vivi/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/screens/LoginScreen.kt
@@ -12,22 +12,34 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavController
 import com.music.innertube.YouTube
@@ -40,14 +52,19 @@ import com.music.vivi.constants.DataSyncIdKey
 import com.music.vivi.constants.InnerTubeCookieKey
 import com.music.vivi.constants.VisitorDataKey
 import com.music.vivi.ui.component.IconButton
+import com.music.vivi.ui.component.InfoLabel
+import com.music.vivi.ui.component.snackbar.SnackbarManager
 import com.music.vivi.ui.utils.backToMain
 import com.music.vivi.utils.normalizeDataSyncId
 import com.music.vivi.utils.rememberPreference
 import com.music.vivi.utils.reportException
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
+import kotlin.time.Duration.Companion.milliseconds
 
 @SuppressLint("SetJavaScriptEnabled")
 @OptIn(ExperimentalMaterial3Api::class, DelicateCoroutinesApi::class)
@@ -63,105 +80,174 @@ fun LoginScreen(
     var accountName by rememberPreference(AccountNameKey, "")
     var accountEmail by rememberPreference(AccountEmailKey, "")
     var accountChannelHandle by rememberPreference(AccountChannelHandleKey, "")
-    var hasCompletedLogin by remember { mutableStateOf(false) }
 
-    var webView: WebView? = null
+    var readyToConfirm by remember { mutableStateOf(false) }
+    var isConfirming by remember { mutableStateOf(false) }
 
-    AndroidView(
-        modifier = Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .fillMaxSize(),
-        factory = { webViewContext ->
-            WebView(webViewContext).apply {
-                webViewClient = object : WebViewClient() {
-                    override fun onPageFinished(view: WebView, url: String?) {
-                        loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
-                        loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
+    var liveDelegatedSessionId by remember { mutableStateOf("") }
 
-                        if (url?.startsWith("https://music.youtube.com") == true && !hasCompletedLogin) {
-                            innerTubeCookie = CookieManager.getInstance().getCookie(url)
-                            hasCompletedLogin = true
+    var webView by remember { mutableStateOf<WebView?>(null) }
 
-                            coroutineScope.launch {
-                                // Small delay to ensure preferences are saved
-                                delay(500)
+    var headerHeightPx by remember { mutableIntStateOf(0) }
+    val headerHeight = with(LocalDensity.current) { headerHeightPx.toDp() }
 
-                                // Initialize YouTube object with new authentication data
-                                YouTube.cookie = innerTubeCookie
-                                YouTube.dataSyncId = normalizeDataSyncId(dataSyncId)
-                                YouTube.visitorData = visitorData
+    fun confirmLogin() {
+        val currentUrl = webView?.url ?: return
+        if (isConfirming) return
+        isConfirming = true
 
-                                Timber.d("Login: YouTube object initialized, validating...")
+        innerTubeCookie = CookieManager.getInstance().getCookie(currentUrl)
+        if (liveDelegatedSessionId.isNotBlank()) {
+            dataSyncId = liveDelegatedSessionId
+        }
 
-                                YouTube.accountInfo().onSuccess {
-                                    accountName = it.name
-                                    accountEmail = it.email.orEmpty()
-                                    accountChannelHandle = it.channelHandle.orEmpty()
+        coroutineScope.launch {
+            // Initialize YouTube object with new authentication data
+            YouTube.cookie = innerTubeCookie
+            YouTube.dataSyncId = normalizeDataSyncId(dataSyncId)
+            YouTube.visitorData = visitorData
 
-                                    Timber.d("Login: Successfully logged in as ${it.name}, restarting app...")
+            Timber.d("Login: YouTube object initialized, validating...")
 
-                                    // Clean up WebView
-                                    webView?.apply {
-                                        stopLoading()
-                                        clearHistory()
-                                        clearCache(true)
-                                        clearFormData()
-                                    }
+            val result = withTimeoutOrNull(20_000.milliseconds) {
+                var attempt = YouTube.accountInfo()
+                if (attempt.isFailure) {
+                    delay(750)
+                    attempt = YouTube.accountInfo()
+                }
+                attempt
+            }
 
-                                    // Restart app to apply login state throughout
-                                    val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
-                                    intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                                    context.startActivity(intent)
-                                    Runtime.getRuntime().exit(0)
-                                }.onFailure {
-                                    Timber.e(it, "Login: Authentication validation failed")
-                                    hasCompletedLogin = false // Allow retry
-                                    reportException(it)
-                                }
+            if (result == null) {
+                Timber.e("Login: Authentication validation timed out")
+                isConfirming = false
+                SnackbarManager.show(R.string.login_failed)
+                return@launch
+            }
+
+            result.onSuccess {
+                accountName = it.name
+                accountEmail = it.email.orEmpty()
+                accountChannelHandle = it.channelHandle.orEmpty()
+
+                Timber.d("Login: Successfully logged in as ${it.name}, restarting app...")
+
+                webView?.apply {
+                    stopLoading()
+                    clearHistory()
+                    clearCache(true)
+                    clearFormData()
+                }
+
+                val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+                intent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                context.startActivity(intent)
+                Runtime.getRuntime().exit(0)
+            }.onFailure {
+                Timber.e(it, "Login: Authentication validation failed")
+                isConfirming = false // Allow retry
+                reportException(it)
+                SnackbarManager.show(R.string.login_failed)
+            }
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AndroidView(
+            modifier = Modifier
+                .windowInsetsPadding(
+                    LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal)
+                )
+                .fillMaxSize()
+                .padding(top = headerHeight),
+            factory = { webViewContext ->
+                WebView(webViewContext).apply {
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageFinished(view: WebView, url: String?) {
+                            loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
+                            loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
+
+                            if (url?.startsWith("https://music.youtube.com") == true) {
+                                readyToConfirm = true
+                            }
+                        }
+                    }
+                    settings.apply {
+                        javaScriptEnabled = true
+                        setSupportZoom(true)
+                        builtInZoomControls = true
+                        displayZoomControls = false
+                    }
+                    addJavascriptInterface(object {
+                        @JavascriptInterface
+                        fun onRetrieveVisitorData(newVisitorData: String?) {
+                            if (newVisitorData != null) {
+                                visitorData = newVisitorData
+                            }
+                        }
+                        @JavascriptInterface
+                        fun onRetrieveDataSyncId(newDataSyncId: String?) {
+                            if (newDataSyncId != null) {
+                                dataSyncId = newDataSyncId
+                            }
+                        }
+                    }, "Android")
+                    webView = this
+                    loadUrl("https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fmusic.youtube.com")
+                }
+            }
+        )
+
+        Column(modifier = Modifier.onGloballyPositioned { headerHeightPx = it.size.height }) {
+            TopAppBar(
+                title = { Text(stringResource(R.string.login)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null
+                        )
+                    }
+                },
+                actions = {
+                    if (readyToConfirm) {
+                        if (isConfirming) {
+                            CircularProgressIndicator(modifier = Modifier.padding(12.dp).size(20.dp))
+                        } else {
+                            androidx.compose.material3.IconButton(onClick = ::confirmLogin) {
+                                Icon(
+                                    painterResource(R.drawable.check),
+                                    contentDescription = stringResource(R.string.login_confirm)
+                                )
                             }
                         }
                     }
                 }
-                settings.apply {
-                    javaScriptEnabled = true
-                    setSupportZoom(true)
-                    builtInZoomControls = true
-                    displayZoomControls = false
-                }
-                addJavascriptInterface(object {
-                    @JavascriptInterface
-                    fun onRetrieveVisitorData(newVisitorData: String?) {
-                        if (newVisitorData != null) {
-                            visitorData = newVisitorData
-                        }
-                    }
-                    @JavascriptInterface
-                    fun onRetrieveDataSyncId(newDataSyncId: String?) {
-                        if (newDataSyncId != null) {
-                            dataSyncId = newDataSyncId
-                        }
-                    }
-                }, "Android")
-                webView = this
-                loadUrl("https://accounts.google.com/ServiceLogin?continue=https%3A%2F%2Fmusic.youtube.com")
-            }
-        }
-    )
+            )
 
-    TopAppBar(
-        title = { Text(stringResource(R.string.login)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null
-                )
+            if (readyToConfirm && !isConfirming) {
+                InfoLabel(text = stringResource(R.string.login_brand_account_hint))
             }
         }
-    )
+    }
+
+    LaunchedEffect(readyToConfirm) {
+        if (!readyToConfirm) return@LaunchedEffect
+        while (isActive && !isConfirming) {
+            webView?.evaluateJavascript(
+                "(function(){try{return (window.ytcfg&&window.ytcfg.get)?(window.ytcfg.get('DELEGATED_SESSION_ID')||''):'';}catch(e){return '';}})();"
+            ) { result ->
+                val id = result?.trim('"').orEmpty().takeUnless { it == "null" }.orEmpty()
+                if (id != liveDelegatedSessionId) {
+                    liveDelegatedSessionId = id
+                }
+            }
+            delay(1000)
+        }
+    }
 
     BackHandler(enabled = webView?.canGoBack() == true) {
         webView?.goBack()

--- a/app/src/main/kotlin/com/music/vivi/utils/DataSyncId.kt
+++ b/app/src/main/kotlin/com/music/vivi/utils/DataSyncId.kt
@@ -1,0 +1,8 @@
+package com.music.vivi.utils
+
+fun normalizeDataSyncId(raw: String?): String? {
+    if (raw == null) return null
+    if (!raw.contains("||")) return raw
+    val delegated = raw.substringAfter("||")
+    return delegated.ifEmpty { raw.substringBefore("||") }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -292,6 +292,8 @@
     <string name="action_logout">Log out</string>
     <string name="action_login">Log in</string>
     <string name="login">Login</string>
+    <string name="login_confirm">Confirm login</string>
+    <string name="login_brand_account_hint">If you want to use a Brand Account, switch to it using the account menu above, then tap the check mark to confirm.</string>
     <string name="show_audio_quality_badge">Show audio quality badge</string>
     <string name="not_logged_in">Not logged in</string>
     <string name="login_failed">Login failed</string>


### PR DESCRIPTION
## Info
Logging in with a Google account that has a Brand Account / secondary channel didn't work:

1. The delegated channel id was silently discarded before it could ever be used.
2. There was no way to actually pick a Brand Account — login completed and the app restarted the instant the WebView first reached `music.youtube.com`, before there was any chance to switch accounts, and with no confirm button to hold that moment open.

**`dfbaaa1` - preserve the delegated channel id**

`DATASYNC_ID` has the shape `"<accountId>||<delegatedChannelId>"`. The segment after `||` is what YouTube's API expects as `onBehalfOfUser` when browsing as a Brand Account. `LoginScreen` truncated at `||` *before* ever persisting the value, throwing it away before it could be used.
- Store the raw `DATASYNC_ID`, normalize on read via a new `normalizeDataSyncId()` (`utils/DataSyncId.kt`).
- Replaced `App.kt`'s inline duplicate of the same normalization logic with a call to the shared function.

**`8ff711d` - let the user actually pick a Brand Account before confirming**

- Reaching `music.youtube.com` now reveals a checkmark action in the top bar (with a hint label) instead of immediately capturing the cookie and restarting. Login only completes when that's tapped, giving time to switch accounts via YouTube's own avatar menu first.

## Screenshot
<img width="395" height="803" src="https://github.com/user-attachments/assets/07e486e6-3b2e-452f-b65c-9be07895d89a" />