### PR TITLE
Crossfade: Manual skip

### DIFF
--- a/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/music/vivi/constants/PreferenceKeys.kt
@@ -192,6 +192,7 @@ val PreventDuplicateTracksInQueueKey = booleanPreferencesKey("preventDuplicateTr
 val CrossfadeEnabledKey = booleanPreferencesKey("crossfadeEnabled")
 val CrossfadeDurationKey = floatPreferencesKey("crossfadeDuration")
 val CrossfadeGaplessKey = booleanPreferencesKey("crossfadeGapless")
+val CrossfadeManualSkipKey = booleanPreferencesKey("crossfadeManualSkip")
 
 val MaxImageCacheSizeKey = intPreferencesKey("maxImageCacheSize")
 val MaxSongCacheSizeKey = intPreferencesKey("maxSongCacheSize")

--- a/app/src/main/kotlin/com/music/vivi/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/music/vivi/playback/MediaLibrarySessionCallback.kt
@@ -14,6 +14,7 @@ import androidx.core.net.toUri
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.session.LibraryResult
@@ -107,6 +108,46 @@ constructor(
             MediaSessionConstants.ACTION_TOGGLE_REPEAT_MODE -> session.player.toggleRepeatMode()
         }
         return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+    }
+
+    /**
+     * Intercepts skip commands coming from *external* controllers — the media
+     * notification, Bluetooth/headset buttons, Android Auto, wearables, etc.
+     * (In-app UI calls the service's player directly and is handled instead
+     * by [PlayerConnection.seekToNext]/[PlayerConnection.seekToPrevious].)
+     *
+     * Note: this callback is marked deprecated upstream in favor of
+     * [MediaSession.setAvailableCommands] + [MediaSession.getControllerForCurrentRequest],
+     * but it's still the simplest way to intercept-and-replace a specific
+     * player command's handling and remains functional as of media3 1.7.1.
+     *
+     * When crossfade-on-manual-skip is enabled we perform the crossfaded
+     * transition ourselves and return [SessionResult.RESULT_INFO_SKIPPED] so
+     * the session reports the command as handled without *also* running its
+     * normal instant seek. Otherwise we defer to the default behavior.
+     */
+    override fun onPlayerCommandRequest(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        playerCommand: Int,
+    ): Int {
+        if (!::service.isInitialized) {
+            return super.onPlayerCommandRequest(session, controller, playerCommand)
+        }
+
+        val handledWithCrossfade = when (playerCommand) {
+            Player.COMMAND_SEEK_TO_NEXT, Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM ->
+                service.manualSkipToNextWithCrossfade()
+            Player.COMMAND_SEEK_TO_PREVIOUS, Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM ->
+                service.manualSkipToPreviousWithCrossfade()
+            else -> false
+        }
+
+        return if (handledWithCrossfade) {
+            SessionResult.RESULT_INFO_SKIPPED
+        } else {
+            super.onPlayerCommandRequest(session, controller, playerCommand)
+        }
     }
 
     @Deprecated("Deprecated in MediaLibrarySession.Callback")

--- a/app/src/main/kotlin/com/music/vivi/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/music/vivi/playback/MusicService.kt
@@ -88,6 +88,7 @@ import com.music.vivi.constants.AutoSkipNextOnErrorKey
 import com.music.vivi.constants.CrossfadeDurationKey
 import com.music.vivi.constants.CrossfadeEnabledKey
 import com.music.vivi.constants.CrossfadeGaplessKey
+import com.music.vivi.constants.CrossfadeManualSkipKey
 import com.music.vivi.constants.DisableLoadMoreWhenRepeatAllKey
 import android.os.Handler
 import android.os.Looper
@@ -271,7 +272,27 @@ class MusicService :
     private var crossfadeEnabled = false
     private var crossfadeDuration = 5000f
     private var crossfadeGapless = true
+    private var crossfadeManualSkipEnabled = false
     private var crossfadeTriggerJob: Job? = null
+
+    /** Holds the combined crossfade-related settings emitted from DataStore. */
+    private data class CrossfadeSettings(
+        val enabled: Boolean,
+        val durationSeconds: Float,
+        val gapless: Boolean,
+        val manualSkip: Boolean,
+    )
+
+    /**
+     * Distinguishes *why* a crossfade transition is starting so [startCrossfade]
+     * knows which media item to target (natural end-of-track vs. a manual
+     * next/previous press).
+     */
+    private enum class CrossfadeTrigger {
+        AUTO,
+        MANUAL_NEXT,
+        MANUAL_PREVIOUS,
+    }
 
     private val secondaryPlayerListener = object : Player.Listener {
         override fun onPlayerError(error: PlaybackException) {
@@ -515,6 +536,7 @@ class MusicService :
         setupAudioFocusRequest()
 
         mediaLibrarySessionCallback.apply {
+            service = this@MusicService
             toggleLike = ::toggleLike
             toggleStartRadio = ::toggleStartRadio
             toggleLibrary = ::toggleLibrary
@@ -946,22 +968,24 @@ class MusicService :
 
         combine(
             dataStore.data.map { prefs ->
-                Triple(
-                    prefs[CrossfadeEnabledKey] ?: false,
-                    prefs[CrossfadeDurationKey] ?: 5f,
-                    prefs[CrossfadeGaplessKey] ?: true
+                CrossfadeSettings(
+                    enabled = prefs[CrossfadeEnabledKey] ?: false,
+                    durationSeconds = prefs[CrossfadeDurationKey] ?: 5f,
+                    gapless = prefs[CrossfadeGaplessKey] ?: true,
+                    manualSkip = prefs[CrossfadeManualSkipKey] ?: false,
                 )
             },
             listenTogetherManager.roomState
-        ) { (enabled, duration, gapless), roomState ->
+        ) { settings, roomState ->
             // Disable crossfade if user is in a listen together room
-            Triple(enabled && roomState == null, duration, gapless)
+            settings.copy(enabled = settings.enabled && roomState == null)
         }
             .distinctUntilChanged()
-            .collect(scope) { (enabled, duration, gapless) ->
-                crossfadeEnabled = enabled
-                crossfadeDuration = duration * 1000f // Convert to ms
-                crossfadeGapless = gapless
+            .collect(scope) { settings ->
+                crossfadeEnabled = settings.enabled
+                crossfadeDuration = settings.durationSeconds * 1000f // Convert to ms
+                crossfadeGapless = settings.gapless
+                crossfadeManualSkipEnabled = settings.manualSkip
             }
 
         if (dataStore.get(PersistentQueueKey, true)) {
@@ -3267,11 +3291,15 @@ class MusicService :
                 toggleLike()
             }
             MusicWidgetReceiver.ACTION_NEXT -> {
-                player.seekToNext()
+                if (!manualSkipToNextWithCrossfade()) {
+                    player.seekToNext()
+                }
                 updateWidgetUI(player.isPlaying)
             }
             MusicWidgetReceiver.ACTION_PREVIOUS -> {
-                player.seekToPrevious()
+                if (!manualSkipToPreviousWithCrossfade()) {
+                    player.seekToPrevious()
+                }
                 updateWidgetUI(player.isPlaying)
             }
             MusicWidgetReceiver.ACTION_UPDATE_WIDGET -> {
@@ -3418,7 +3446,7 @@ class MusicService :
         return current.albumTitle != null && current.albumTitle == next.albumTitle
     }
 
-    private fun startCrossfade() {
+    private fun startCrossfade(trigger: CrossfadeTrigger = CrossfadeTrigger.AUTO) {
         if (isCrossfading) return
 
         // Preserve player state before creating the secondary player
@@ -3426,11 +3454,16 @@ class MusicService :
         val savedRepeatMode = runBlocking { dataStore.get(RepeatModeKey, REPEAT_MODE_OFF) }
         val savedShuffleEnabled = runBlocking { dataStore.get(ShuffleModeKey, false) }
 
-        // For repeat-one, crossfade back into the same track
-        val targetIndex = if (savedRepeatMode == REPEAT_MODE_ONE) {
-            player.currentMediaItemIndex
-        } else {
-            player.nextMediaItemIndex
+        val targetIndex = when {
+            // Manual "previous" skip: crossfade back into the previous track.
+            trigger == CrossfadeTrigger.MANUAL_PREVIOUS -> {
+                if (!player.hasPreviousMediaItem()) return
+                player.previousMediaItemIndex
+            }
+            // For repeat-one at the natural end of the track, crossfade back into the same track.
+            trigger == CrossfadeTrigger.AUTO && savedRepeatMode == REPEAT_MODE_ONE -> player.currentMediaItemIndex
+            // Natural end-of-track advance, or a manual "next" skip.
+            else -> player.nextMediaItemIndex
         }
         if (targetIndex == C.INDEX_UNSET) return
 
@@ -3464,6 +3497,53 @@ class MusicService :
             val shufflePlaylistFirst = dataStore.get(ShufflePlaylistFirstKey, false)
             applyShuffleOrder(player.currentMediaItemIndex, player.mediaItemCount, shufflePlaylistFirst)
         }
+    }
+
+    /**
+     * Attempts a crossfaded manual skip to the next track, in response to the
+     * user pressing "next" (in-app button/gesture, notification, widget,
+     * Bluetooth/headset button, Android Auto, etc.) rather than the track
+     * ending naturally.
+     *
+     * Returns `true` if the crossfade transition was started, meaning the
+     * caller should NOT also perform an instant [Player.seekToNext]. Returns
+     * `false` when crossfade (or crossfade-on-manual-skip) is disabled, when
+     * a crossfade is already in progress, or when there is no next item to
+     * crossfade into — in which case the caller should fall back to its
+     * normal instant-skip behavior.
+     */
+    fun manualSkipToNextWithCrossfade(): Boolean {
+        if (!crossfadeEnabled || !crossfadeManualSkipEnabled) return false
+        if (isCrossfading) return false
+        if (castConnectionHandler?.isCasting?.value == true) return false
+        if (!player.hasNextMediaItem()) return false
+        if (player.duration == C.TIME_UNSET) return false
+        if (crossfadeGapless && isNextItemGapless()) return false
+
+        crossfadeTriggerJob?.cancel()
+        crossfadeTriggerJob = null
+        startCrossfade(CrossfadeTrigger.MANUAL_NEXT)
+        return isCrossfading
+    }
+
+    /**
+     * Attempts a crossfaded manual skip to the previous track. Same contract
+     * as [manualSkipToNextWithCrossfade], but for the "previous" direction.
+     * Callers that implement a "restart the current song if we're more than
+     * a few seconds in" behavior should only call this from the branch that
+     * actually moves to the previous track, not the restart branch.
+     */
+    fun manualSkipToPreviousWithCrossfade(): Boolean {
+        if (!crossfadeEnabled || !crossfadeManualSkipEnabled) return false
+        if (isCrossfading) return false
+        if (castConnectionHandler?.isCasting?.value == true) return false
+        if (!player.hasPreviousMediaItem()) return false
+        if (player.duration == C.TIME_UNSET) return false
+
+        crossfadeTriggerJob?.cancel()
+        crossfadeTriggerJob = null
+        startCrossfade(CrossfadeTrigger.MANUAL_PREVIOUS)
+        return isCrossfading
     }
 
     private fun performCrossfadeSwap() {

--- a/app/src/main/kotlin/com/music/vivi/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/music/vivi/playback/PlayerConnection.kt
@@ -407,11 +407,16 @@ class PlayerConnection(
                 castHandler.skipToNext()
                 return
             }
-            player.seekToNext()
-            if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) {
-                player.prepare()
+            // Try a crossfaded manual skip first (only engages if the user
+            // enabled "Crossfade on manual skip"); fall back to an instant
+            // seek otherwise.
+            if (!service.manualSkipToNextWithCrossfade()) {
+                player.seekToNext()
+                if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) {
+                    player.prepare()
+                }
+                player.playWhenReady = true
             }
-            player.playWhenReady = true
             onSkipNext?.invoke()
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Error in seekToNext")
@@ -444,12 +449,15 @@ class PlayerConnection(
                 player.playWhenReady = true
                 onRestartSong?.invoke()
             } else {
-                // Otherwise go to previous media item
-                player.seekToPreviousMediaItem()
-                if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) {
-                    player.prepare()
+                // Otherwise go to previous media item — try a crossfaded
+                // manual skip first, falling back to an instant seek.
+                if (!service.manualSkipToPreviousWithCrossfade()) {
+                    player.seekToPreviousMediaItem()
+                    if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) {
+                        player.prepare()
+                    }
+                    player.playWhenReady = true
                 }
-                player.playWhenReady = true
                 onSkipPrevious?.invoke()
             }
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/music/vivi/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/MiniPlayer.kt
@@ -337,9 +337,13 @@ private fun NewMiniPlayer(
 
                                 if (shouldChangeSong) {
                                     if (currentOffset > 0 && canSkipPrevious) {
-                                        playerConnection.player.seekToPreviousMediaItem()
+                                        if (!playerConnection.service.manualSkipToPreviousWithCrossfade()) {
+                                            playerConnection.player.seekToPreviousMediaItem()
+                                        }
                                     } else if (currentOffset <= 0 && canSkipNext) {
-                                        playerConnection.player.seekToNext()
+                                        if (!playerConnection.service.manualSkipToNextWithCrossfade()) {
+                                            playerConnection.player.seekToNext()
+                                        }
                                     }
                                 }
                                 coroutineScope.launch {
@@ -726,9 +730,13 @@ private fun LegacyMiniPlayer(
 
                                 if (shouldChangeSong) {
                                     if (currentOffset > 0 && canSkipPrevious) {
-                                        playerConnection.player.seekToPreviousMediaItem()
+                                        if (!playerConnection.service.manualSkipToPreviousWithCrossfade()) {
+                                            playerConnection.player.seekToPreviousMediaItem()
+                                        }
                                     } else if (currentOffset <= 0 && canSkipNext) {
-                                        playerConnection.player.seekToNext()
+                                        if (!playerConnection.service.manualSkipToNextWithCrossfade()) {
+                                            playerConnection.player.seekToNext()
+                                        }
                                     }
                                 }
                                 coroutineScope.launch { offsetXAnimatable.animateTo(0f, animationSpec) }

--- a/app/src/main/kotlin/com/music/vivi/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/player/Thumbnail.kt
@@ -352,9 +352,13 @@ fun Thumbnail(
         if (!thumbnailLazyGridState.isScrollInProgress || !swipeThumbnail || itemScrollOffset != 0 || currentMediaIndex < 0) return@LaunchedEffect
 
         if (currentItem > currentMediaIndex && canSkipNext) {
-            playerConnection.player.seekToNext()
+            if (!playerConnection.service.manualSkipToNextWithCrossfade()) {
+                playerConnection.player.seekToNext()
+            }
         } else if (currentItem < currentMediaIndex && canSkipPrevious) {
-            playerConnection.player.seekToPreviousMediaItem()
+            if (!playerConnection.service.manualSkipToPreviousWithCrossfade()) {
+                playerConnection.player.seekToPreviousMediaItem()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/music/vivi/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/com/music/vivi/ui/screens/settings/PlayerSettings.kt
@@ -49,6 +49,7 @@ import com.music.vivi.constants.AutoDownloadOnLikeKey
 import com.music.vivi.constants.CrossfadeDurationKey
 import com.music.vivi.constants.CrossfadeEnabledKey
 import com.music.vivi.constants.CrossfadeGaplessKey
+import com.music.vivi.constants.CrossfadeManualSkipKey
 import com.music.vivi.constants.AutoLoadMoreKey
 import com.music.vivi.constants.AutoSkipNextOnErrorKey
 import com.music.vivi.constants.DisableLoadMoreWhenRepeatAllKey
@@ -100,6 +101,10 @@ fun PlayerSettings(
     val (crossfadeGapless, onCrossfadeGaplessChange) = rememberPreference(
         CrossfadeGaplessKey,
         defaultValue = true
+    )
+    val (crossfadeManualSkip, onCrossfadeManualSkipChange) = rememberPreference(
+        CrossfadeManualSkipKey,
+        defaultValue = false
     )
     val (persistentQueue, onPersistentQueueChange) = rememberPreference(
         PersistentQueueKey,
@@ -381,6 +386,27 @@ fun PlayerSettings(
                             )
                         },
                         onClick = { onCrossfadeGaplessChange(!crossfadeGapless) }
+                    ))
+                    add(Material3SettingsItem(
+                        icon = painterResource(R.drawable.fast_forward),
+                        title = { Text(stringResource(R.string.crossfade_manual_skip)) },
+                        description = { Text(stringResource(R.string.crossfade_manual_skip_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = crossfadeManualSkip,
+                                onCheckedChange = onCrossfadeManualSkipChange,
+                                thumbContent = {
+                                    Icon(
+                                        painter = painterResource(
+                                            id = if (crossfadeManualSkip) R.drawable.check else R.drawable.close
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize)
+                                    )
+                                }
+                            )
+                        },
+                        onClick = { onCrossfadeManualSkipChange(!crossfadeManualSkip) }
                     ))
                 }
                 add(Material3SettingsItem(

--- a/app/src/main/res/values-az/vivi_strings_az.xml
+++ b/app/src/main/res/values-az/vivi_strings_az.xml
@@ -177,8 +177,6 @@
     <string name="lyrics_glow_effect_desc">Əlavə et glowing animation və bounce effekt -a active mahnı sözləri</string>
     <string name="enable_better_lyrics">Aktiv et Better Mahnı sözləri</string>
     <string name="enable_better_lyrics_desc">Istifadə et Better Mahnı sözləri provayder üçün word-by-word sinxronlaşdırıldı mahnı sözləri</string>
-    <string name="enable_simpmusic">Aktiv et SimpMusiqi Mahnı sözləri</string>
-    <string name="enable_simpmusic_desc">Istifadə et SimpMusiqi Mahnı sözləri provayder üçün sinxronlaşdırıldı mahnı sözləri</string>
     <string name="auto_scroll">Re-sinxronlaşdır</string>
     <string name="slim">Yığcam</string>
     <string name="slim_navbar">Yığcam aşağı naviqasiya paneli</string>

--- a/app/src/main/res/values/vivi_strings.xml
+++ b/app/src/main/res/values/vivi_strings.xml
@@ -335,6 +335,8 @@
     <string name="crossfade_duration">Crossfade duration</string>
     <string name="crossfade_gapless">Disable for gapless albums</string>
     <string name="crossfade_gapless_desc">Don\'t crossfade if the album is gapless</string>
+    <string name="crossfade_manual_skip">Crossfade on manual skip</string>
+    <string name="crossfade_manual_skip_desc">Also crossfade when you press next/previous, instead of only at the end of a track</string>
     <string name="crossfade_beta_title">Beta Feature</string>
     <string name="crossfade_beta_message">Crossfade is a new feature and may have bugs. If you experience any issues, please report them.\n\nThis feature disables audio offload due to technical limitations.</string>
 


### PR DESCRIPTION
## 🚀 What does this PR do?
- [ ] ✨ Adds a new feature
The idea is to make crossfade work even when the user manually changes to the next track. When pressing the next/skip button, the current song could gradually fade out while the next song fades in, using the same crossfade duration configured by the user.

## 📸 Screenshots / Recordings
<img width="540" height="1212" alt="Screenshot_20260905-114627" src="https://github.com/user-attachments/assets/3baff94c-7a2d-46f8-a49d-3296129163f9" />



## 🛠️ Checklist
- [ ] My code follows the project's style guidelines.
- [x ] I have tested my changes on an Android device/emulator.
- [ ] I have verified that no new warnings/errors are introduced.
- [ ] I have updated the documentation (if necessary).

## 📝 Additional Notes
